### PR TITLE
simplejson is deprecated, so remove it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==1.6.5
 Markdown==2.3.1
-simplejson==3.4.0
 uuid==1.30
 psycopg2==2.5.1
 nose==1.3.0


### PR DESCRIPTION
AFAICT, nothing in DMT actually uses simplejson, and it's deprecated anyway, so might as well remove it.
