### PR TITLE
fix extra margin in header css

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -157,3 +157,8 @@ dd:hover .priority-select {
     width: auto;
     height: auto;
 }
+
+form.navbar-form {
+    margin-top: 0;
+    margin-bottom: 0;
+}


### PR DESCRIPTION
@thraxil This fixes the header -- it was annoying me that it was vertically off-center because of the input box.

before:
![screenshot from 2014-06-20 12 35 57](https://cloud.githubusercontent.com/assets/59292/3344775/5122e244-f8af-11e3-90b9-11a2a55639e2.png)

after:
![screenshot from 2014-06-20 12 36 09](https://cloud.githubusercontent.com/assets/59292/3344777/55e6174c-f8af-11e3-9172-08360426a407.png)
