### PR TITLE
wrap script tag in the same feature flag for notifications ui

### DIFF
--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -543,8 +543,10 @@ by <a href="{{history_item.user.get_absolute_url}}">{{history_item.user.fullname
 
 
 {% block js %}
+{% flag notification_ui %}
 <script data-main="{{STATIC_URL}}js/item"
 				src="{{STATIC_URL}}js/libs/require/require.js"></script>
+{% endflag %}
 <script>
 $(document).ready(function() 
     { 


### PR DESCRIPTION
@nikolas, looks like we need to wrap the <script> tag in the same feature flag. The JS depends on the markup being there on the page, so when the feature flag is off, the markup doesn't go in, but the JS still runs. Getting some sentry errors: https://sentry.ccnmtl.columbia.edu/dmt/dmt/group/159/
