### PR TITLE
fix regression in add bug to project

### DIFF
--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -488,7 +488,6 @@ class TestItemWorkflow(TestCase):
             project.get_absolute_url() + "add_bug/",
             dict(title='test bug', description='test',
                  priority='1', milestone=i.milestone.mid,
-                 owner=i.owner.username,
                  assigned_to=i.assigned_to.username,
                  tags="tagone, tagtwo"))
         r = self.c.get(project.get_absolute_url())

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -515,6 +515,7 @@ class ProjectAddItemView(LoggedInMixin, View):
     item_type = "action item"
 
     def post(self, request, pk):
+        user = get_object_or_404(Claim, django_user=request.user).pmt_user
         project = get_object_or_404(Project, pid=pk)
         title = request.POST.get('title', u"Untitled")
         if len(title) == 0:
@@ -524,7 +525,8 @@ class ProjectAddItemView(LoggedInMixin, View):
         assigned_to = get_object_or_404(
             User, username=request.POST.get('assigned_to'))
         owner = get_object_or_404(
-            User, username=request.POST.get('owner'))
+            User, username=request.POST.get(
+                'owner', user.username))
         milestone = get_object_or_404(
             Milestone, mid=request.POST.get('milestone'))
         priority = request.POST.get('priority', '1')


### PR DESCRIPTION
the recent feature to allow users to set an owner on an action item
broke the add bug form, which doesn't have that option and so
needs to default to the request.user as the owner.
