### PR TITLE
Fix dom structure for action item modals

### DIFF
--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -110,16 +110,16 @@
         <h4 class="modal-title" id="inprogress-label">Mark as In Progress</h4>
       </div>
       <div class="modal-body">
-				<div class="form-group">
-					<textarea name="comment" class="form-control" rows="5"></textarea>
-				</div>
+          <div class="form-group">
+              <textarea name="comment" class="form-control" rows="5"></textarea>
+          </div>
+          <div class="form-group">
+              <label for="progress-time-input">Time</label>
+              <input type="text" name="time" placeholder="time"
+              id="progress-time-input"
+              class="form-control" />
+          </div>
       </div>
-				<div class="form-group">
-					<label for="progress-time-input">Time</label>
-					<input type="text" name="time" placeholder="time"
-								 id="progress-time-input"
-								 class="form-control" />
-				</div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         <input type="submit" class="btn btn-primary" value="Mark as In Progress" />
@@ -171,16 +171,16 @@
         <h4 class="modal-title" id="reopen-label">Reopen</h4>
       </div>
       <div class="modal-body">
-				<div class="form-group">
-					<textarea name="comment" class="form-control" rows="5"></textarea>
-				</div>
+          <div class="form-group">
+              <textarea name="comment" class="form-control" rows="5"></textarea>
+          </div>
+          <div class="form-group">
+              <label for="reopen-time-input">Time</label>
+              <input type="text" name="time" placeholder="time"
+              id="reopen-time-input"
+              class="form-control" />
+          </div>
       </div>
-				<div class="form-group">
-					<label for="reopen-time-input">Time</label>
-					<input type="text" name="time" placeholder="time"
-								 id="reopen-time-input"
-								 class="form-control" />
-				</div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         <input type="submit" class="btn btn-primary" value="Reopen" />
@@ -200,16 +200,16 @@
         <h4 class="modal-title" id="add-comment-label">Add Comment</h4>
       </div>
       <div class="modal-body">
-					<div class="form-group">
-						<textarea name="comment" class="form-control" rows="5"></textarea>
-					</div>
+          <div class="form-group">
+              <textarea name="comment" class="form-control" rows="5"></textarea>
+          </div>
+          <div class="form-group">
+              <label for="comment-time-input">Time</label>
+              <input type="text" name="time" placeholder="time"
+              id="comment-time-input"
+              class="form-control" />
+          </div>
       </div>
-				<div class="form-group">
-					<label for="comment-time-input">Time</label>
-					<input type="text" name="time" placeholder="time"
-								 id="comment-time-input"
-								 class="form-control" />
-				</div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         <input type="submit" class="btn btn-primary" value="Add Comment" />


### PR DESCRIPTION
The `form-group` element for Time inputs was outside the `modal-body` elements for adding comments, reopening items, and marking items as in-progress. This was creating this style issue:
![screenshot from 2014-07-01 10 33 20](https://cloud.githubusercontent.com/assets/59292/3444765/3716b9d6-0131-11e4-9cdc-73a53cc1281b.png)

Where it should look like this:
![screenshot from 2014-07-01 10 35 38](https://cloud.githubusercontent.com/assets/59292/3444768/3a384b84-0131-11e4-8cf7-c33261751e89.png)
