### PR TITLE
Fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,9 @@ shell: ./ve/bin/python
 	$(MANAGE) shell_plus
 
 clean:
-	rm -rf ve
-	rm -rf media/CACHE
-	rm -rf reports
-	rm -f celerybeat-schedule
-	rm -f .coverage
+	rm -rf ve media/CACHE reports node_modules
+	rm -f celerybeat-schedule .coverage
 	find . -name '*.pyc' -exec rm {} \;
-	for PACKAGE in `ls node_modules`; do npm rm $(PACKAGE); done
 
 pull:
 	git pull


### PR DESCRIPTION
My npm uninstall script was giving me an error:

```
npm WARN uninstall not installed in /home/nnyby/src/dmt/node_modules: "dmt"
```

rm -rf node_modules is simpler and works better.
