### PR TITLE
fix group link on user detail page

### DIFF
--- a/dmt/templates/main/user_detail.html
+++ b/dmt/templates/main/user_detail.html
@@ -48,7 +48,9 @@
 {% with object.user_groups as groups %}
 {% if groups %}
 <dt>Groups</dt><dd>
-{% for g in groups %}<a href="{{g.get_absolute_url}}">{{g.group_fullname}}</a>{% if not forloop.last %}, {% endif %}
+{% for g in groups %}
+<a href="{% url 'group_detail' g.username %}">
+    {{g.group_fullname}}</a>{% if not forloop.last %}, {% endif %}
 {% endfor %}
 </dd>
 {% endif %}


### PR DESCRIPTION
This link was pointing to the group's user page, not the new group detail page.
