### PR TITLE
change s3 url format

### DIFF
--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -873,7 +873,7 @@ class SignS3View(LoggedInMixin, View):
             hmac.new(AWS_SECRET_KEY, put_request, sha1).digest())
         signature = urllib.quote_plus(signature.strip())
 
-        url = 'https://%s.s3.amazonaws.com/%s' % (S3_BUCKET, object_name)
+        url = 'https://s3.amazonaws.com/%s/%s' % (S3_BUCKET, object_name)
         signed_request = '%s?AWSAccessKeyId=%s&Expires=%d&Signature=%s' % (
             url, AWS_ACCESS_KEY, expires, signature)
 


### PR DESCRIPTION
Changing to this url format, along with updating our CORS configuration for the buckets to be just like the dev bucket fixed the 403 error for me on staging.
