### PR TITLE
only capture the few WIND/CAS affiliations that we care about

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -192,9 +192,14 @@ AUTHENTICATION_BACKENDS = ('djangowind.auth.WindAuthBackend',
 WIND_BASE = "https://wind.columbia.edu/"
 WIND_SERVICE = "cnmtl_full_np"
 WIND_PROFILE_HANDLERS = ['djangowind.auth.CDAPProfileHandler']
-WIND_AFFIL_HANDLERS = ['djangowind.auth.AffilGroupMapper',
+WIND_AFFIL_HANDLERS = ['whitelistaffilmapper.WhitelistAffilGroupMapper',
                        'djangowind.auth.StaffMapper',
                        'djangowind.auth.SuperuserMapper']
+AFFILS_WHITELIST = [
+    'tlc.cunix.local:columbia.edu',
+    'tlcxml.cunix.local:columbia.edu',
+    'staff.cunix.local:columbia.edu',
+]
 WIND_STAFF_MAPPER_GROUPS = ['tlc.cunix.local:columbia.edu']
 WIND_SUPERUSER_MAPPER_GROUPS = ['anp8', 'jb2410', 'zm4', 'egr2107',
                                 'sld2131', 'amm8', 'mar227', 'jed2161',

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ mechanize==0.2.5
 recordtype==1.1
 urlparse2==1.0
 sqlparse==0.1.11
-
+whitelistaffilmapper==0.1.0
 
 djangowind==0.12.1
 django-staticmedia==0.2.2


### PR DESCRIPTION
DMT is internal, so there's no reason to map course affiliations to Django Groups.
pull in a very simple whitelist mapper (https://github.com/ccnmtl/whitelistaffilmapper)
and configure it to only map users into the couple groups that we might
even remotely care about.
