### PR TITLE
include INPROGRESS items in estimate reports

### DIFF
--- a/dmt/main/tasks.py
+++ b/dmt/main/tasks.py
@@ -122,7 +122,7 @@ def total_hours_logged_by_project():
 def total_hours_estimated_by_project():
     q = """SELECT m.pid, extract ('epoch' from sum(i.estimated_time)::interval)
            FROM items i, milestones m
-           WHERE i.status = 'OPEN'
+           WHERE i.status in ('OPEN', 'INPROGRESS')
              AND i.mid = m.mid GROUP BY m.pid;"""
     cursor = connection.cursor()
     cursor.execute(q)
@@ -144,7 +144,7 @@ def total_hours_logged_by_milestone():
 def total_hours_estimated_by_milestone():
     q = """SELECT i.mid, extract ('epoch' from sum(i.estimated_time)::interval)
            FROM items i
-           WHERE i.status = 'OPEN'
+           WHERE i.status in ('OPEN', 'INPROGRESS')
            GROUP BY i.mid;"""
     cursor = connection.cursor()
     cursor.execute(q)


### PR DESCRIPTION
for Graphite purposes, items that are INPROGRESS should probably get
counted in the same category as OPEN items. ie, red on the graphs.
