### PR TITLE
switch auth backend to CAS + SAML

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -186,11 +186,9 @@ COMPRESS_URL = "/media/"
 COMPRESS_ROOT = "media/"
 
 # WIND settings
-
-AUTHENTICATION_BACKENDS = ('djangowind.auth.WindAuthBackend',
+CAS_BASE = "https://cas.columbia.edu/"
+AUTHENTICATION_BACKENDS = ('djangowind.auth.SAMLAuthBackend',
                            'django.contrib.auth.backends.ModelBackend', )
-WIND_BASE = "https://wind.columbia.edu/"
-WIND_SERVICE = "cnmtl_full_np"
 WIND_PROFILE_HANDLERS = ['djangowind.auth.CDAPProfileHandler']
 WIND_AFFIL_HANDLERS = ['djangowind.auth.AffilGroupMapper',
                        'djangowind.auth.StaffMapper',

--- a/dmt/templates/admin/login.html
+++ b/dmt/templates/admin/login.html
@@ -2,7 +2,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
-{% block stylesheet %}{% load adminmedia %}{% admin_media_prefix %}css/login.css{% endblock %}
+{% block stylesheet %}{{STATIC_URL}}admin/css/login.css{% endblock %}
 
 {% block bodyclass %}login{% endblock %}
 
@@ -15,32 +15,12 @@
 <p class="errornote">{{ error_message }}</p>
 {% endif %}
 <div id="content-main">
-<form method="get" action="https://wind.columbia.edu/login">
-<input type="hidden" name="service" value="cnmtl_full_np" />
-<input type="hidden" name="destination" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/windlogin/?next=/admin/&this_is_the_login_form=1" />
+<form method="get" action="https://cas.columbia.edu/cas/login">
+<input type="hidden" name="destination" value="https://{{ request.get_host }}/accounts/caslogin/?next=/admin/&this_is_the_login_form=1" />
 <p>If you have a Columbia UNI, you already have an account and can
-login through WIND with it</p>
+login through CAS with it</p>
 <input type="submit" value="Here" />
 </form>
-<p>otherwise: </p>
-
-<form action="{{ app_path }}" method="post" id="login-form">
-  <div class="form-row">
-    <label for="id_username">{% trans 'Username:' %}</label> <input type="text" name="username" id="id_username" />
-  </div>
-  <div class="form-row">
-    <label for="id_password">{% trans 'Password:' %}</label> <input type="password" name="password" id="id_password" />
-    <input type="hidden" name="this_is_the_login_form" value="1" />
-    <input type="hidden" name="post_data" value="{{ post_data }}" /> {#<span class="help">{% trans 'Have you <a href="/password_reset/">forgotten your password</a>?' %}</span>#}
-  </div>
-  <div class="submit-row">
-    <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
-  </div>
-</form>
-
-<script type="text/javascript">
-document.getElementById('id_username').focus()
-</script>
 </div>
 {% endblock %}
 

--- a/dmt/templates/registration/login.html
+++ b/dmt/templates/registration/login.html
@@ -1,9 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
 Please log in:
-<form method="get" action="{{ wind_base }}login" class="well">
-<input type="hidden" name="service" value="{{ wind_service }}" />
-<input type="hidden" name="destination" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/windlogin/?next={{ next }}" />
+<form method="get" action="{{ cas_base }}cas/login" class="well">
+<input type="hidden" name="destination" value="https://{{ request.get_host }}/accounts/caslogin/?next={{ next }}" />
 <input type="submit" value="LOG IN" class="btn btn-primary"/></p>
 </form>
 

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -33,7 +33,7 @@ logout_page = (
     r'^accounts/logout/$',
     'django.contrib.auth.views.logout',
     {'next_page': redirect_after_logout})
-if hasattr(settings, 'WIND_BASE'):
+if hasattr(settings, 'CAS_BASE'):
     auth_urls = (r'^accounts/', include('djangowind.urls'))
     logout_page = (
         r'^accounts/logout/$',

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ urlparse2==1.0
 sqlparse==0.1.11
 
 
-djangowind==0.12.1
+djangowind==0.13.1
 django-staticmedia==0.2.2
 South==0.8.4
 django-annoying==0.7.6


### PR DESCRIPTION
the DMT prod and staging URLs have been registered with our CAS service
with CUIT, so this should be good to go now.

The big caveat here is that with CAS, now to develop on the DMT locally,
if you need to login/logout, you will need to have your development
machine registered, and you'll need to run a local https proxy.

It's a pain, but it's something we have to get used to for working with CAS
apps.
