### PR TITLE
Don't allow blank project names

### DIFF
--- a/dmt/main/forms.py
+++ b/dmt/main/forms.py
@@ -1,3 +1,4 @@
+import re
 from django import forms
 from django.forms import ModelForm
 from .models import StatusUpdate, Node, User, Project, Milestone, Item
@@ -35,6 +36,15 @@ class ProjectCreateForm(ModelForm):
                 choices=(('true', 'Public'),
                          ('false', 'Private')))
         }
+
+    def clean_name(self):
+        return self.cleaned_data.get('name', '').strip()
+
+    def clean_target_date(self):
+        target_date = self.cleaned_data.get('target_date')
+        if not re.match(r'\d{4}-\d{1,2}-\d{1,2}', target_date):
+            raise forms.ValidationError(
+                'Invalid target date: %s' % target_date)
 
 
 class ProjectUpdateForm(ModelForm):

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -271,6 +271,15 @@ class TestProjectViews(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertTrue('This field is required.' in r.content)
 
+        r = self.c.post(reverse('project_create'),
+                        {'name': '      ',
+                         'description': 'description',
+                         'pub_view': 'public',
+                         'target_date': '2020-04-28',
+                         'test_wiki_category': ''})
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue('This field cannot be blank.' in r.content)
+
     def test_create_project_post_requires_target_date(self):
         r = self.c.post(reverse('project_create'),
                         {'name': 'Test project name',


### PR DESCRIPTION
- Also adds a validator for target_date in the form definition, where it
  belongs.
