### PR TITLE
optimize and simplify my projects page query

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -531,18 +531,13 @@ ORDER BY hours_logged DESC;
         """, [start, end])
         return projects
 
-    @staticmethod
-    def all_projects_by_last_mod():
-        projects = Project.objects.raw("""
-SELECT
-    m.pid,
-    date_trunc('minute',max(i.last_mod)) AS last_mod
-FROM milestones m
-LEFT OUTER JOIN items i
-    ON m.mid = i.mid
-GROUP BY m.pid
-        """)
-        return projects
+    def last_mod(self):
+        r = Item.objects.filter(
+            milestone__project=self).order_by("-last_mod")
+        try:
+            return r[0].last_mod
+        except IndexError:
+            return None
 
 
 class Document(models.Model):

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -3,7 +3,6 @@ from .factories import (
     ItemFactory, NodeFactory, EventFactory, CommentFactory, UserFactory,
     StatusUpdateFactory, NotifyFactory, GroupFactory,
     AttachmentFactory)
-from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -11,7 +10,6 @@ from waffle import Flag
 from dmt.claim.models import Claim, PMTUser
 from dmt.main.models import Attachment, Item, ItemClient, Milestone, Project
 import json
-import unittest
 
 
 class BasicTest(TestCase):
@@ -355,10 +353,6 @@ class MyProjectViewTests(TestCase):
                                          status="active")
         Claim.objects.create(django_user=self.u, pmt_user=self.pu)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_my_projects_page_in_project(self):
         p = ProjectFactory()
         p.add_personnel(self.pu)
@@ -367,10 +361,6 @@ class MyProjectViewTests(TestCase):
         self.assertTrue(p.name in r.content)
         self.assertTrue(reverse('project_detail', args=(p.pid,)) in r.content)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_my_projects_page_not_in_project(self):
         p = ProjectFactory()
         r = self.client.get(reverse('my_project_list'))

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -465,16 +465,9 @@ class MyProjectListView(LoggedInMixin, ListView):
     template_name = 'main/my_projects.html'
 
     def get_queryset(self):
-        current_user = \
-            get_object_or_404(Claim, django_user=self.request.user).pmt_user
-        project_last_mod_list = Project.all_projects_by_last_mod()
+        current_user = get_object_or_404(
+            Claim, django_user=self.request.user).pmt_user
         project_list = current_user.personnel_on()
-        for p in project_list:
-            last_mod = [x.last_mod
-                        for x in project_last_mod_list if x.pid == p.pid]
-            if last_mod:
-                p.last_mod = last_mod[0]
-
         return project_list
 
 


### PR DESCRIPTION
rather than pull up every single project in the database, sorted by last_mod time
via a fairly complex and PG specific query, then merging that in with the list of projects
that the user is actually on, we just pull up the list of projects that the user is on
and then seperately calculate the last_mod time for that project.

The former approach could be faster if a user is on a lot of projects since it gets all
the last_mod times in one go. However, aside from a couple users, the vast majority
of staff are only on a small subset of the total projects, so a lot of that up front work
is wasted. Even for me (and I'm probably on a lot more projects than most staff),
this change took page load from 5 seconds down to 2 seconds. In the process, it also
eliminated a PG specific query, so the view could be properly tested against SQLite again.

This still involves N+1 queries, which is never great. The long term solution for making this
page fast will probably be to denormalize and actually put a last_mod column on the
projects table, with a hook to update it whenever an item in the project is touched. That
will be straightforward to do once the perl code is eliminated.
