### PR TITLE
Add mdx_linkify to to make URLs links (PMT #95749)

### DIFF
--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -126,7 +126,7 @@ class AddCommentView(LoggedInMixin, View):
         body = request.POST.get('comment', u'')
         if body == '':
             return HttpResponseRedirect(item.get_absolute_url())
-        item.add_comment(user, markdown.markdown(body))
+        item.add_comment(user, markdown.markdown(body, extensions=['linkify']))
         item.touch()
         item.update_email(body, user)
         log_time(item, user, request)
@@ -139,7 +139,8 @@ class ResolveItemView(LoggedInMixin, View):
         item = get_object_or_404(Item, pk=pk)
         user = get_object_or_404(Claim, django_user=request.user).pmt_user
         r_status = request.POST.get('r_status', u'FIXED')
-        comment = markdown.markdown(request.POST.get('comment', u''))
+        comment = markdown.markdown(request.POST.get('comment', u''),
+                                    extensions=['linkify'])
         if (item.assigned_to.username == item.owner.username and
                 item.owner.username == user.username):
             # streamline self-assigned item verification
@@ -159,7 +160,8 @@ class InProgressItemView(LoggedInMixin, View):
     def post(self, request, pk):
         item = get_object_or_404(Item, pk=pk)
         user = get_object_or_404(Claim, django_user=request.user).pmt_user
-        comment = markdown.markdown(request.POST.get('comment', u''))
+        comment = markdown.markdown(request.POST.get('comment', u''),
+                                    extensions=['linkify'])
         item.mark_in_progress(user, comment)
         item.touch()
         item.update_email("marked as in progress\n----\n"
@@ -174,7 +176,8 @@ class VerifyItemView(LoggedInMixin, View):
     def post(self, request, pk):
         item = get_object_or_404(Item, pk=pk)
         user = get_object_or_404(Claim, django_user=request.user).pmt_user
-        comment = markdown.markdown(request.POST.get('comment', u''))
+        comment = markdown.markdown(request.POST.get('comment', u''),
+                                    extensions=['linkify'])
         item.verify(user, comment)
         item.touch()
         item.update_email("verified\n-----\n"
@@ -189,7 +192,8 @@ class ReopenItemView(LoggedInMixin, View):
     def post(self, request, pk):
         item = get_object_or_404(Item, pk=pk)
         user = get_object_or_404(Claim, django_user=request.user).pmt_user
-        comment = markdown.markdown(request.POST.get('comment', u''))
+        comment = markdown.markdown(request.POST.get('comment', u''),
+                                    extensions=['linkify'])
         item.reopen(user, comment)
         item.touch()
         item.update_email("reopened\n-----\n"
@@ -207,7 +211,8 @@ class ReassignItemView(LoggedInMixin, View):
         assigned_to = get_object_or_404(
             User,
             username=request.POST.get('assigned_to', ''))
-        comment = markdown.markdown(request.POST.get('comment', u''))
+        comment = markdown.markdown(request.POST.get('comment', u''),
+                                    extensions=['linkify'])
         item.reassign(user, assigned_to, comment)
         item.touch()
         item.update_email("reassigned\n----\n"
@@ -224,7 +229,8 @@ class ChangeOwnerItemView(LoggedInMixin, View):
         owner = get_object_or_404(
             User,
             username=request.POST.get('owner', ''))
-        comment = markdown.markdown(request.POST.get('comment', u''))
+        comment = markdown.markdown(request.POST.get('comment', u''),
+                                    extensions=['linkify'])
         item.change_owner(user, owner, comment)
         item.touch()
         item.update_email("owner changed\n-----\n"

--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -598,18 +598,20 @@
 <h2>HISTORY</h2>
 
 <table class="table">
-{% for history_item in object.history %}
-<tr>
-<td class="{{history_item.status_class}}">{{history_item.status}}</td>
-<td>
-by <a href="{{history_item.user.get_absolute_url}}">{{history_item.user.fullname}}</a><br />
-<nobr>at {{history_item.timestamp}}</nobr>
-</td>
-<td>
-{{history_item.comment|safe}}
-</td>
-</tr>
-{% endfor %}
+    {% for history_item in object.history %}
+    <tr>
+        <td class="{{history_item.status_class}}">{{history_item.status}}</td>
+        <td>
+            by <a href="{{history_item.user.get_absolute_url}}">
+                {{history_item.user.fullname}}</a>
+            <br />
+            <nobr>at {{history_item.timestamp}}</nobr>
+        </td>
+        <td>
+            {{history_item.comment|safe}}
+        </td>
+    </tr>
+    {% endfor %}
 </table>
 
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==1.6.5
-Markdown==2.3.1
+Markdown==2.4.1
+mdx_linkify==0.5
 uuid==1.30
 psycopg2==2.5.1
 nose==1.3.0


### PR DESCRIPTION
Adds a markdown extension that transforms `<p>http://example.org/</p>` to `<p><a href="http://example.org/">http://example.org/</a></p>` for new comments / text fields.
- Updates Markdown to 2.4.1
