### PR TITLE
Fix comment wrapping

### DIFF
--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -597,22 +597,25 @@
 
 <h2>HISTORY</h2>
 
-<table class="table">
+<div class="item-history">
     {% for history_item in object.history %}
-    <tr>
-        <td class="{{history_item.status_class}}">{{history_item.status}}</td>
-        <td>
+    <hr />
+    <div class="row">
+        <div class="col-md-1 {{history_item.status_class}}">
+            {{history_item.status}}
+        </div>
+        <div class="col-md-3">
             by <a href="{{history_item.user.get_absolute_url}}">
                 {{history_item.user.fullname}}</a>
             <br />
             <nobr>at {{history_item.timestamp}}</nobr>
-        </td>
-        <td>
+        </div>
+        <div class="col-md-8 item-comment">
             {{history_item.comment|safe}}
-        </td>
-    </tr>
+        </div>
+    </div>
     {% endfor %}
-</table>
+</div>
 
 {% endblock %}
 

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -57,22 +57,22 @@ body > .container {
   color: blue;
 }
 
-td.open, td.new, td.reopened, span.open {
+td.open, span.open, div.open, td.new, div.new, td.reopened, div.reopened {
 	font-weight: bold;
 	color: #f00;
 }
 
-td.closed, span.closed {
+td.closed, span.closed, div.closed {
 		font-weight: bold;
 		color: #009900;
 }
 
-td.resolved, span.resolved {
+td.resolved, span.resolved, div.resolved {
 		font-weight: bold;
 		color: #069;
 }
 
-td.verified, span.verified {
+td.verified, span.verified, div.verified {
 		font-weight: bold;
 		color: #009900;
 }
@@ -102,19 +102,19 @@ td.verified, span.verified {
   color: #f00;
 }
 
-td.ok {
+td.ok, div.ok {
 		color: #9999cc;
 }
-td.upcoming {
+td.upcoming, div.upcoming {
 		color: #069;
 }
-td.due {
+td.due, div.due {
 		color: #009900;
 }
-td.overdue {
+td.overdue, div.overdue {
 		color: #f60;
 }
-td.late {
+td.late, div.late {
 		color: #f00;
 }
 
@@ -194,4 +194,13 @@ footer.page-footer {
     padding-bottom: 40px;
     margin-top: 60px;
     text-align: center;
+}
+
+.item-history hr {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.item-history .item-comment {
+    word-wrap: break-word;
 }


### PR DESCRIPTION
This was an issue with chrome, but not firefox. Long comments wouldn't
get wrapped properly -- they were trailing off the screen. I couldn't
figure out a way to fix this in the `<td>` without using
`table-layout: fixed;` on the table, which caused other problems. I'm
using the bootstrap grid system for this now which is working better.
