### PR TITLE
Use mdx_linkify on all the fields where we're using markdown

### DIFF
--- a/dmt/templates/main/dashboard.html
+++ b/dmt/templates/main/dashboard.html
@@ -90,7 +90,7 @@
 <div class="col-md-3">
 <a href="{{su.project.get_absolute_url}}">{{su.project.name}}</a></div>
 <div class="col-md-6">
- {{su.body|markdown}}
+ {{su.body|markdown:"linkify"}}
 </div>
 <div class="col-md-3">
  &mdash; <a href="{{su.user.get_absolute_url}}">{{su.user.fullname}}</a>

--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -506,7 +506,11 @@
 </dl>
 
 <hr />
-{{object.description|markdown}}
+
+<div class="item-description">
+    {{object.description|markdown:"linkify"}}
+</div>
+
 <hr />
 
 <div class="btn-toolbar">
@@ -574,12 +578,12 @@
 			{% else %}
 			<img src="{{attachment.src}}" />
 			{% endif %}
-			{{attachment.description|markdown}}
+			{{attachment.description|markdown:"linkify"}}
 	</td></tr>
 	{% else %}
 	<tr>
 		<td colspan="4">
-			{{attachment.description|markdown}}
+			{{attachment.description|markdown:"linkify"}}
 			{% if attachment.url %}
 			<p><a href="{{attachment.url}}">Download</a></p>
 			{% else %}

--- a/dmt/templates/main/milestone_detail.html
+++ b/dmt/templates/main/milestone_detail.html
@@ -37,7 +37,7 @@
 </dl>
 
 {% if object.description %}
-{{object.description|markdown}}
+{{object.description|markdown:"linkify"}}
 {% endif %}
 
 {% if object.item_set.count %}

--- a/dmt/templates/main/node_detail.html
+++ b/dmt/templates/main/node_detail.html
@@ -37,7 +37,7 @@ by <a href="{{object.author.get_absolute_url}}">{{object.author.fullname}}</a>
 </div>
 </form>
 
-{{object.body|markdown}}
+{{object.body|markdown:"linkify"}}
 
 <ul class="nav nav-tabs">
 	{% if object.replies %}
@@ -56,7 +56,7 @@ by <a href="{{object.author.get_absolute_url}}">{{object.author.fullname}}</a>
 			<span class="text-muted">by <a href="{{reply.author.get_absolute_url}}">{{reply.author.fullname}}</a><br />
 			at {{reply.added}}</span>
 	</td>
-	<td>{{reply.body|markdown}}</td>
+	<td>{{reply.body|markdown:"linkify"}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/dmt/templates/main/node_list.html
+++ b/dmt/templates/main/node_list.html
@@ -48,7 +48,7 @@ by <a href="{{n.author.get_absolute_url}}">{{n.author.fullname}}</a>
 {% endfor %}</p>
 {% endif %}
 
-{{n.body|markdown}}
+{{n.body|markdown:"linkify"}}
 
 {% endfor %}
 {% if is_paginated %}

--- a/dmt/templates/main/project_detail.html
+++ b/dmt/templates/main/project_detail.html
@@ -144,7 +144,7 @@
 			<dt>Status</dt>
 			<dd>{{object.status}}</dd>
 			<dt>Description</dt>
-			<dd>{{object.description|markdown}}</dd>
+			<dd>{{object.description|markdown:"linkify"}}</dd>
 			<dt>URL</dt>
 			<dd>{{object.url}}</dd>
 {% if object.wiki_category %}
@@ -305,7 +305,7 @@ by <a href="{{n.author.get_absolute_url}}">{{n.author.fullname}}</a>
 <a href="/tag/{{tag.slug}}/"><span class="label label-info">{{tag}}</span></a>
 </span>
 {% endfor %}</p>{% endif %}
-{{n.body|markdown}}
+{{n.body|markdown:"linkify"}}
 
 		{% endfor %}
 	</div>

--- a/dmt/templates/main/user_detail.html
+++ b/dmt/templates/main/user_detail.html
@@ -43,7 +43,7 @@
 {% if object.phone %}<dt>Phone<dt><dd>{{object.phone}}</dd>{% endif %}
 {% if object.office %}<dt>Office<dt><dd>{{object.office}}</dd>{% endif %}
 {% if object.bio %}
-<dt>Bio</dt><dd>{{object.bio|markdown}}</dd>
+<dt>Bio</dt><dd>{{object.bio|markdown:"linkify"}}</dd>
 {% endif %}
 {% with object.user_groups as groups %}
 {% if groups %}
@@ -171,7 +171,7 @@
 <a href="/tag/{{tag.slug}}/"><span class="label label-info">{{tag}}</span></a>
 </span>
 {% endfor %}</p>{% endif %}
-{{n.body|markdown}}
+{{n.body|markdown:"linkify"}}
 
 		{% endfor %}
 	</div>


### PR DESCRIPTION
Fixes PMT #96043

I realized that we're not always saving markdown-generated HTML to the
database. This adds the 'linkify' extension wherever we use the markdown
template tag. Action item descriptions, user bios, etc should all have
correct link tags now.
