### PR TITLE
Fix bug in add trackers form (PMT #96360)

### DIFF
--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from dmt.claim.models import Claim
 from dmt.main.models import Client, Item, Milestone, Notify, Project, User
+from dmt.main.utils import new_duration
 
 from .serializers import (
     ClientSerializer, ItemSerializer, MilestoneSerializer, NotifySerializer,
@@ -30,14 +31,7 @@ class ItemHoursView(View):
     def post(self, request, pk):
         item = get_object_or_404(Item, iid=pk)
         user = get_object_or_404(Claim, django_user=request.user).pmt_user
-        try:
-            d = Duration(request.POST.get('time', "1 hour"))
-        except InvalidDuration:
-            # eventually, this needs to get back to the user
-            # via form validation, but for now
-            # we just deal with it...
-            d = Duration("0 minutes")
-
+        d = new_duration(request.POST.get('time', '1 hour'))
         td = d.timedelta()
         item.add_resolve_time(user, td)
         return HttpResponse("ok")
@@ -183,13 +177,7 @@ class AddTrackerView(View):
     def post(self, request):
         pid = request.POST.get('pid', None)
         task = request.POST.get('task', None)
-        try:
-            d = Duration(request.POST.get('time', "1 hour"))
-        except InvalidDuration:
-            # eventually, this needs to get back to the user
-            # via form validation, but for now
-            # we just deal with it...
-            d = Duration("0 minutes")
+        d = new_duration(request.POST.get('time', '1 hour'))
         client_uni = request.POST.get('client', '')
 
         td = d.timedelta()

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.db import connection, models
+from django.db.models.aggregates import Sum
 from django.conf import settings
 from datetime import timedelta, datetime
 from interval.fields import IntervalField
@@ -717,6 +718,11 @@ class Item(models.Model):
         merged = comments + events
         merged.sort()
         return merged
+
+    def get_resolve_time(self):
+        total = ActualTime.objects.filter(item=self).aggregate(
+            Sum('actual_time'))
+        return total['actual_time__sum']
 
     def add_resolve_time(self, user, time):
         completed = datetime.now()

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -7,9 +7,10 @@ from .factories import (
     AttachmentFactory, ClientFactory,
     ActualTimeFactory, MilestoneFactory)
 from datetime import datetime, timedelta
+from simpleduration import Duration
 from dmt.main.models import (
-    InGroup, HistoryItem, Milestone, Notify, ProjectUser, truncate_string,
-    HistoryEvent
+    ActualTime, InGroup, HistoryItem, Milestone, Notify, ProjectUser,
+    truncate_string, HistoryEvent
 )
 
 
@@ -204,6 +205,21 @@ class ItemModelTest(TestCase):
         i2 = ItemFactory()
         i.copy_clients_to_new_item(i2)
         self.assertTrue(c in [ic.client for ic in i2.itemclient_set.all()])
+
+    def test_add_resolve_time(self):
+        i = ItemFactory()
+        u = UserFactory()
+        td = Duration('1 hour').timedelta()
+        i.add_resolve_time(u, td)
+        self.assertEqual(ActualTime.objects.count(), 1)
+
+    def test_get_resolve_time(self):
+        i = ItemFactory()
+        u = UserFactory()
+        td = Duration('1 hour').timedelta()
+        i.add_resolve_time(u, td)
+        resolve_time = i.get_resolve_time()
+        self.assertEqual(resolve_time, timedelta(0, 3600))
 
 
 class HistoryItemTest(TestCase):

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -10,6 +10,7 @@ from waffle import Flag
 from dmt.claim.models import Claim, PMTUser
 from dmt.main.models import Attachment, Item, ItemClient, Milestone, Project
 from dmt.main.tests.support.mixins import LoggedInTestMixin
+from datetime import timedelta
 import json
 
 
@@ -1065,4 +1066,6 @@ class TestAddTrackersView(LoggedInTestMixin, TestCase):
         self.assertTrue('Tracker added' in r.content)
         self.assertTrue(p.name in r.content)
 
-        # TODO: test that tracker is created
+        i = Item.objects.last()
+        resolve_time = i.get_resolve_time()
+        self.assertEqual(resolve_time, timedelta(0, 3600))

--- a/dmt/main/utils.py
+++ b/dmt/main/utils.py
@@ -1,5 +1,18 @@
 import ntpath
 import re
+from simpleduration import Duration, InvalidDuration
+
+
+def new_duration(timestr):
+    try:
+        d = Duration(timestr)
+    except InvalidDuration:
+        # eventually, this needs to get back to the user
+        # via form validation, but for now
+        # we just deal with it...
+        d = Duration('0 minutes')
+
+    return d
 
 
 def interval_to_hours(duration):


### PR DESCRIPTION
The tracker item created wasn't actually getting add_resolve_time called
on it, so there was no time added. I've added a get_resolve_time()
function to action items, making this easier to test.
