### PR TITLE
Don't run get_resolve_time tests on SQLite

### DIFF
--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.test import TestCase
+from django.conf import settings
 from django.core import mail
 import unittest
 from .factories import (
@@ -212,14 +213,53 @@ class ItemModelTest(TestCase):
         td = Duration('1 hour').timedelta()
         i.add_resolve_time(u, td)
         self.assertEqual(ActualTime.objects.count(), 1)
+        actualtime = ActualTime.objects.first()
+        self.assertEqual(actualtime.actual_time, timedelta(0, 3600))
 
-    def test_get_resolve_time(self):
+    # SQLite can't handle aggregate functions on datetime fields
+    # https://docs.djangoproject.com/en/dev/ref/models/querysets/
+    # #aggregation-functions
+    @unittest.skipUnless(
+        settings.DATABASES['default']['ENGINE'] ==
+        'django.db.backends.postgresql_psycopg2',
+        "This test requires PostgreSQL")
+    def test_get_resolve_zero(self):
+        i = ItemFactory()
+        u = UserFactory()
+        td = Duration('0h').timedelta()
+        i.add_resolve_time(u, td)
+        resolve_time = i.get_resolve_time()
+        self.assertEqual(resolve_time, timedelta(0, 0))
+
+    @unittest.skipUnless(
+        settings.DATABASES['default']['ENGINE'] ==
+        'django.db.backends.postgresql_psycopg2',
+        "This test requires PostgreSQL")
+    def test_get_resolve_time_1h(self):
         i = ItemFactory()
         u = UserFactory()
         td = Duration('1 hour').timedelta()
         i.add_resolve_time(u, td)
         resolve_time = i.get_resolve_time()
         self.assertEqual(resolve_time, timedelta(0, 3600))
+
+    @unittest.skipUnless(
+        settings.DATABASES['default']['ENGINE'] ==
+        'django.db.backends.postgresql_psycopg2',
+        "This test requires PostgreSQL")
+    def test_get_resolve_time_multiple_times(self):
+        i = ItemFactory()
+
+        u = UserFactory()
+        td = Duration('1 hour').timedelta()
+        i.add_resolve_time(u, td)
+
+        u = UserFactory()
+        td = Duration('1 hour').timedelta()
+        i.add_resolve_time(u, td)
+
+        resolve_time = i.get_resolve_time()
+        self.assertEqual(resolve_time, timedelta(0, 7200))
 
 
 class HistoryItemTest(TestCase):

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -3,6 +3,7 @@ from .factories import (
     ItemFactory, NodeFactory, EventFactory, CommentFactory, UserFactory,
     StatusUpdateFactory, NotifyFactory, GroupFactory,
     AttachmentFactory)
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -12,6 +13,7 @@ from dmt.main.models import Attachment, Item, ItemClient, Milestone, Project
 from dmt.main.tests.support.mixins import LoggedInTestMixin
 from datetime import timedelta
 import json
+import unittest
 
 
 class BasicTest(TestCase):
@@ -1048,6 +1050,10 @@ class TestAddTrackersView(LoggedInTestMixin, TestCase):
         r = self.client.post(reverse('add_trackers'), {})
         self.assertEqual(r.status_code, 302)
 
+    @unittest.skipUnless(
+        settings.DATABASES['default']['ENGINE'] ==
+        'django.db.backends.postgresql_psycopg2',
+        "This test requires PostgreSQL")
     def test_add_trackers_post_tracker(self):
         p = ProjectFactory(caretaker=self.pu)
         MilestoneFactory(project=p)


### PR DESCRIPTION
SQLite doesn't do aggregate functions on datetime fields:
https://docs.djangoproject.com/en/1.7/ref/models/querysets/#aggregation-functions
