### PR TITLE
Only disable notification checkbox if it's checked

### DIFF
--- a/dmt/templates/main/client_detail.html
+++ b/dmt/templates/main/client_detail.html
@@ -140,9 +140,3 @@
 <div id="client-container"></div>
 
 {% endblock %}
-
-{% block js %}
-<script data-main="{{STATIC_URL}}js/src/client_edit"
-		src="{{STATIC_URL}}js/libs/require/require.js"></script>
-
-{% endblock %}

--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -469,16 +469,19 @@
 <dd>
 <div class="input-group" id="item-notification-container">
 <label
-    class="disabled"
-    for="input_notification">
+     {% if assigned_to_current_user and notifications_enabled_for_current_user %}
+     class="disabled"
+     {% endif %}
 
+     for="input_notification">
     <input
-        {% if assigned_to_current_user %}
+        {% if assigned_to_current_user and notifications_enabled_for_current_user %}
             disabled="disabled"
-        {% endif %}
-        {% if notifications_enabled_for_current_user %}
+            checked="checked"
+        {% elif notifications_enabled_for_current_user %}
             checked="checked"
         {% endif %}
+
         class="form-control"
         type="checkbox"
         placeholder="add tags (comma separated)"
@@ -656,10 +659,5 @@ function s3_upload() {
 }
 </script>
 
-{% endflag %}
-
-{% flag notification_ui %}
-<script data-main="{{STATIC_URL}}js/src/item"
-				src="{{STATIC_URL}}js/libs/require/require.js"></script>
 {% endflag %}
 {% endblock %}

--- a/media/js/src/client_edit.js
+++ b/media/js/src/client_edit.js
@@ -35,6 +35,10 @@ require([
     'models/client',
     'views/client'
 ], function($, Backbone, Client, AppView) {
+    if ($('#client-id').length === 0) {
+        return;
+    }
+
     var csrftoken = getCookie('csrftoken');
     var oldSync = Backbone.sync;
 

--- a/media/js/src/item.js
+++ b/media/js/src/item.js
@@ -35,6 +35,10 @@ require([
     'models/item',
     'views/item'
 ], function($, Backbone, Item, AppView) {
+    if ($('#item-id').length === 0) {
+        return;
+    }
+
     var csrftoken = getCookie('csrftoken');
     var oldSync = Backbone.sync;
 

--- a/media/js/src/main.js
+++ b/media/js/src/main.js
@@ -1,4 +1,12 @@
 require([
+    // libs
+    '../libs/jquery/jquery-min',
+    '../libs/underscore/underscore-min',
+    '../libs/backbone/backbone-min',
+
+    // src
+    'client_edit',
     'forms/add_time_form',
-    'forms/add_tracker_form'
+    'forms/add_tracker_form',
+    'item'
 ], function() {});

--- a/media/js/src/views/client.js
+++ b/media/js/src/views/client.js
@@ -3,6 +3,10 @@ define([
     'underscore',
     'backbone'
 ], function($, _, Backbone) {
+    if ($('#client-template').length === 0) {
+        return;
+    }
+
     var ClientView = Backbone.View.extend(
         {
             tagName: 'div',

--- a/media/js/src/views/item.js
+++ b/media/js/src/views/item.js
@@ -4,6 +4,10 @@ define([
     'backbone',
     'models/notify'
 ], function($, _, Backbone, Notify) {
+    if ($('#item-template').length === 0) {
+        return;
+    }
+
     var ItemView = Backbone.View.extend(
         {
             tagName: 'div',


### PR DESCRIPTION
We should always allow the user to manually opt-in to notifications on action items.

Other JS fixes:
- notifications ajax request thing broke in this commit:
  9ca7808522b5ec1f778620168a467aecbd59d861
  and is fixed now
- The backbone apps are now loaded with main.js, since my JS
  re-organization broke that as well.
