### PR TITLE
include item description in email when adding a new item

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -393,7 +393,7 @@ class Project(models.Model):
             item.tags.add(*tags)
         item.setup_default_notification()
         item.add_project_notification()
-        item.update_email("%s added" % type, owner)
+        item.update_email("%s added\n\n%s" % (type, description), owner)
         milestone.update_milestone()
 
     def recent_forum_posts(self, count=10):


### PR DESCRIPTION
When you assign an action item/bug to someone, they should be able to read the description right in the email instead of having to go off to the web. This is how the PMT used to work. Don't know how it slipped past.
