### PR TITLE
added links to pages in the old PMT on the global nav

### DIFF
--- a/dmt/templates/base.html
+++ b/dmt/templates/base.html
@@ -101,8 +101,8 @@
               </a>
               <ul class="dropdown-menu">
                 <li><a href="#" class="disabled">Owned items</a></li>
-                <li><a href="#" class="disabled">Watched items</a></li>
-                <li><a href="#" class="disabled">Someday/Maybe</a></li>
+                <li><a href="http://pmt.ccnmtl.columbia.edu/home.pl?mode=watched_items" class="old-pmt"><span class="glyphicon glyphicon-transfer"></span> Watched items</a></li>
+                <li><a href="http://pmt.ccnmtl.columbia.edu/home.pl?mode=someday_maybe" class="old-pmt"><span class="glyphicon glyphicon-transfer"></span> Someday/Maybe</a></li>
               </ul>
             </li>
             <li class="dropdown">
@@ -142,7 +142,7 @@
               <span class="hidden-sm">Users/Groups</span> <span class="caret"></span>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="#" class="disabled">My groups</a></li>
+                <li><a href="http://pmt.ccnmtl.columbia.edu/home.pl?mode=my_groups" class="old-pmt"><span class="glyphicon glyphicon-transfer"></span> My groups</a></li>
                 <li><a href="{% url 'group_list' %}">All groups</a></li>
                 <li><a href="{% url 'user_list' %}?status=active">All users</a></li>
               </ul>


### PR DESCRIPTION
I forgot to include the links to the old PMT pages. The are now in the menu of the global nav
