### PR TITLE
viewing a nonexistent group should be a 404, not a 500

### DIFF
--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -998,6 +998,10 @@ class GroupTest(TestCase):
         r = self.client.get(reverse('group_list'))
         self.assertTrue('grp_foo' in r.content)
 
+    def test_nonexistent_group(self):
+        r = self.client.get(reverse('group_detail', args=('not_real',)))
+        self.assertTrue(r.status_code, 404)
+
 
 class UserTest(TestCase):
     def setUp(self):

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -982,7 +982,7 @@ class GroupDetailView(LoggedInMixin, ListView):
         ctx = super(GroupDetailView, self).get_context_data(**kwargs)
 
         group_name = self.kwargs['pk']
-        group = User.objects.get(username=group_name)
+        group = get_object_or_404(User, username=group_name)
         ctx['group_name'] = InGroup.verbose_name(group.fullname)
         ctx['group'] = group
         ctx['eligible_users'] = self.eligible_users(group_name)


### PR DESCRIPTION
fixes Sentry: /dmt/dmt/group/351/
