### PR TITLE
restore prominent weekly report button to home page

### DIFF
--- a/dmt/templates/main/index.html
+++ b/dmt/templates/main/index.html
@@ -36,6 +36,11 @@
                 Add Trackers
             </a>
         </li>
+				<li>
+					  <a href="/report/user/{{pmt_user.username}}/weekly/">
+						    Weekly Report
+					  </a>
+				</li>
     </ul>
 </p>
 


### PR DESCRIPTION
IMO, the weekly report needs to be made very prominent to encourage time tracking
and self-reflection.
