### PR TITLE
weekly report emails

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -203,6 +203,25 @@ class User(models.Model):
                     target_percentage=target_percentage,
                     behind=week_percentage < (target_percentage - 20))
 
+    def send_weekly_report(self):
+        r = self.progress_report()
+        body = self.weekly_report_email_body(r['hours_logged'], r['behind'])
+        send_mail(
+            "PMT Weekly Report",
+            body, settings.SERVER_EMAIL,
+            [self.email], fail_silently=settings.DEBUG)
+
+    def weekly_report_email_body(self, hours_logged, behind):
+        if behind:
+            return (
+                """This week you have only logged %.1f hours.\n\n"""
+                """Now is a good time to take care of that.\n"""
+                % hours_logged)
+        else:
+            return (
+                """You've logged %.1f hours this week. Good job!\n"""
+                % hours_logged)
+
     def group_fullname(self):
         f = self.fullname
         return f.replace(" (group)", "")

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -89,6 +89,24 @@ class UserModelTest(TestCase):
         u = UserFactory(fullname="foo (group)")
         self.assertEqual(u.group_fullname(), "foo")
 
+    def test_weekly_report_email_body(self):
+        u = UserFactory()
+        r = u.weekly_report_email_body(1.0, True)
+        self.assertEqual(
+            r,
+            """This week you have only logged 1.0 hours.\n\n"""
+            """Now is a good time to take care of that.\n""")
+        r = u.weekly_report_email_body(1.0, False)
+        self.assertEqual(
+            r,
+            """You've logged 1.0 hours this week. Good job!\n""")
+
+    def test_send_weekly_report(self):
+        u = UserFactory()
+        u.send_weekly_report()
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "PMT Weekly Report")
+
 
 class ProjectUserTest(TestCase):
     def test_completed_time_for_interval(self):


### PR DESCRIPTION
Every Friday at noon, the DMT will email all active users a very brief summary of how many hours they have logged so far this week, encouraging and reminding anyone who is behind that they should get their hours logged.
