### PR TITLE
Make all of the top-left logo clickable

### DIFF
--- a/dmt/templates/base.html
+++ b/dmt/templates/base.html
@@ -50,7 +50,7 @@
   <nav class="navbar navbar-default navbar-inverse navbar-dmt navbar-fixed-top" role="navigation">
     <div class="container container-theme">
       <div class="navbar-brand theme-brand">
-      <a href="/"><img src="/media/img/shim.gif" /></a>
+      <a class="dmt-logo-link" href="/"><img src="/media/img/shim.gif" /></a>
       </div>
       <div class="navbar-top-level">
         <ul class="user-menu navbar-right">

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -493,6 +493,13 @@ span.attachment-action-text {
   height: 95px;
   margin-left: 0 !important;
   background: transparent url('/media/img/bg-honeycomb-brand.png') left top no-repeat;
+  padding: 0;
+}
+
+.theme-brand a.dmt-logo-link {
+    display: block;
+    width: 100%;
+    height: 100%;
 }
 
 .theme-brand img {


### PR DESCRIPTION
@zmustapha The edges of the top-left PMT logo weren't clickable because of some padding -- this PR fixes that.
