### PR TITLE
knock lxml back to 3.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ backports.ssl-match-hostname==3.4.0.2
 tornado==3.1.1
 cssselect==0.9.1
 BeautifulSoup==3.2.1
-lxml==3.4.0
+lxml==3.2.3
 fuzzywuzzy==0.4.0
 sure==1.2.7
 ipython==0.13.2


### PR DESCRIPTION
dmt-celery builds have been failing, not because anything is actually
broken with lxml 3.4.0, but because compiling it requires more
memory than Krusty seems to have; so it keeps getting oom-killed
during the compile. :(
