### PR TITLE
Allow logging in as a local user, instead of only CAS, in /admin/

### DIFF
--- a/dmt/templates/admin/login.html
+++ b/dmt/templates/admin/login.html
@@ -22,6 +22,23 @@ login through CAS with it</p>
 <input type="submit" value="Here" />
 </form>
 </div>
+
+<p>otherwise: </p>
+
+<form action="{{ app_path }}" method="post" id="login-form">
+    {% csrf_token %}
+  <div class="form-row">
+    <label for="id_username">{% trans 'Username:' %}</label> <input type="text" name="username" id="id_username" />
+  </div>
+  <div class="form-row">
+    <label for="id_password">{% trans 'Password:' %}</label> <input type="password" name="password" id="id_password" />
+    <input type="hidden" name="this_is_the_login_form" value="1" />
+    <input type="hidden" name="post_data" value="{{ post_data }}" /> {#<span class="help">{% trans 'Have you <a href="/password_reset/">forgotten your password</a>?' %}</span>#}
+  </div>
+  <div class="submit-row">
+    <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
+  </div>
+</form>
 {% endblock %}
 
 


### PR DESCRIPTION
I need to be able to log in if I'm working on DMT in a non-CAS
registered domain, like on my laptop. If there's a better way of doing
this, let me know, but right now this seems like the best way to me.
