### PR TITLE
Fix "NaN-NaN-NaN" bug in bug/item forms in Firefox

### DIFF
--- a/dmt/templates/main/project_add_action_item_form.html
+++ b/dmt/templates/main/project_add_action_item_form.html
@@ -22,7 +22,8 @@
                             var milestoneActionItemTargets = [];
                             {% for milestone in object.milestone_set.all %}
                                 milestoneActionItemTargets.push(
-                                    new Date('{{milestone.target_date}}'));
+                                    new Date('{{milestone.target_date.isoformat}}')
+                                );
                             {% endfor %}
                         </script>
                         <label for="action_item-milestones">Milestone</label>

--- a/dmt/templates/main/project_add_bug_form.html
+++ b/dmt/templates/main/project_add_bug_form.html
@@ -31,7 +31,8 @@
                             var milestoneBugTargets = [];
                             {% for milestone in object.milestone_set.all %}
                                 milestoneBugTargets.push(
-                                    new Date('{{milestone.target_date}}'));
+                                    new Date('{{milestone.target_date.isoformat}}')
+                                );
                             {% endfor %}
                         </script>
                         <label for="bug-milestones">Milestone</label>

--- a/media/js/src/forms/project_add_action_item_form.js
+++ b/media/js/src/forms/project_add_action_item_form.js
@@ -23,6 +23,10 @@ require([
     }
 
     $(document).ready(function() {
+        if (!$('#add-action-item-form')) {
+            return;
+        }
+
         var preview = new MarkdownPreview(
             $('textarea#dmt-project-new-item-desc'),
             $('.dmt-markdown-project-item-preview')

--- a/media/js/src/forms/project_add_bug_form.js
+++ b/media/js/src/forms/project_add_bug_form.js
@@ -23,6 +23,10 @@ require([
     }
 
     $(document).ready(function() {
+        if (!$('#add-bug-form')) {
+            return;
+        }
+
         var preview = new MarkdownPreview(
             $('textarea#dmt-project-new-bug-desc'),
             $('.dmt-markdown-project-bug-preview')

--- a/media/js/src/forms/utils.js
+++ b/media/js/src/forms/utils.js
@@ -2,7 +2,11 @@ define([], function() {
     var FormUtils = function() {};
 
     FormUtils.prototype.refreshTargetDate = function($selectEl, targetDates) {
-        if (!targetDates || targetDates.length <= 0) {
+        if (
+            typeof $().datepicker === 'undefined' ||
+                !targetDates ||
+                targetDates.length <= 0
+        ) {
             return;
         }
 


### PR DESCRIPTION
PMT #97819

Firefox was parsing `new Date('Jan. 14 2014');` into an `InvalidDate`,
while Chrome parsed it fine. Note that Firefox parses
`new Date('Jan 14 2014')` (without the dot) correctly.

I considered using moment.js to parse this date, but apparently that's
not moment.js's job. It throws a deprecation warning when you try to use
it to parse dates like that: https://github.com/moment/moment/issues/1407

The way I've solved it is by using datetime.date's `isoformat()`
function to always render this date in a predictable way that should
always be parsed by `new Date();`.
