### PR TITLE
CSV/XLS export of all hours logged for a project. PMT #98179

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -573,6 +573,11 @@ ORDER BY hours_logged DESC;
         except IndexError:
             return None
 
+    def all_actual_times(self):
+        return ActualTime.objects.filter(
+            item__milestone__project=self,
+        ).order_by('completed')
+
 
 class Document(models.Model):
     did = models.AutoField(primary_key=True)

--- a/dmt/report/tests/test_views.py
+++ b/dmt/report/tests/test_views.py
@@ -134,3 +134,12 @@ class PassedMilestonesViewTests(LoggedInTestMixin, TestCase):
         r = self.client.get(reverse('passed_milestones_report'))
         self.assertEqual(r.status_code, 200)
         self.assertTrue(m.name in r.content)
+
+
+class ProjectHoursViewTests(LoggedInTestMixin, TestCase):
+    def test_report(self):
+        i = ItemFactory()
+        p = i.milestone.project
+        r = self.client.get(
+            reverse('project-hours-report', args=[p.pid]) + "?format=csv")
+        self.assertEqual(r.status_code, 200)

--- a/dmt/report/urls.py
+++ b/dmt/report/urls.py
@@ -14,6 +14,9 @@ urlpatterns = patterns(
         views.ActiveProjectsExportView.as_view(),
         name='active_projects_report_export'),
 
+    url(r'^project/(?P<pk>\d+)/hours/$', views.ProjectHoursView.as_view(),
+        name='project-hours-report'),
+
     url(r'^user/(?P<pk>\w+)/weekly/$', views.UserWeeklyView.as_view(),
         name='user_weekly_report'),
     url(r'^user/(?P<pk>\w+)/yearly/$', views.UserYearlyView.as_view(),

--- a/dmt/templates/main/project_detail.html
+++ b/dmt/templates/main/project_detail.html
@@ -306,15 +306,13 @@
   
   <img src="{{GRAPHITE_BASE}}?target=ccnmtl.app.gauges.dmt.projects.{{project.pid}}.hours_logged&target=ccnmtl.app.gauges.dmt.projects.{{project.pid}}.hours_estimated&_salt=1369503684.466&height=50&colorList=%2366cc66%2C%23cc6666&hideLegend=true&hideAxes=true&yMin=0&width=800&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=stacked&from=-1years"
      width="100%" />
-  
-    <ul>[NOT IMPLEMENTED YET]
-      <li>weekly</li>
-      <li>monthly</li>
-      <li>quarterly</li>
-      <li>semestral</li>
-      <li>annual</li>
-      <li>custom</li>
-    </ul>
+
+	<ul>
+		<li>Export project hours logged:
+			<a href="{% url 'project-hours-report' project.pid %}?format=csv">CSV</a>
+			or
+			<a href="{% url 'project-hours-report' project.pid %}?format=xls">XLS</a>
+	</ul>
   
   </div>
   


### PR DESCRIPTION
now a PM can get all the data they could possibly want about hours logged
in one spreadsheet so they can slice and dice and analyze it however they want.
