### PR TITLE
automatically bump upcoming Someday/Maybe milestones into the future

### DIFF
--- a/dmt/main/tasks.py
+++ b/dmt/main/tasks.py
@@ -192,3 +192,20 @@ def weekly_report_emails():
 def user_weekly_report_email(username):
     u = User.objects.get(username=username)
     u.send_weekly_report()
+
+
+@periodic_task(run_every=crontab(hour=0, minute=0))
+def bump_someday_maybe_target_dates():
+    """ Someday/Maybe milestones are "special" and
+    should never actually reach a target date.
+    so once a day, we take any that are upcoming
+    and push them far into the future again. """
+    now = datetime.now()
+    upcoming = now + timedelta(weeks=4)
+    future = now + timedelta(weeks=52)
+    for m in Milestone.objects.filter(
+            name="Someday/Maybe",
+            target_date__lt=upcoming,
+            status='OPEN'):
+        m.target_date = future.date()
+        m.save()

--- a/dmt/main/tests/test_tasks.py
+++ b/dmt/main/tests/test_tasks.py
@@ -1,6 +1,10 @@
 from django.test import TestCase
+from .factories import MilestoneFactory
+from datetime import datetime, timedelta
+from dmt.main.models import Milestone
 from dmt.main.tasks import (
     get_item_counts_by_status, item_counts, hours_logged,
+    bump_someday_maybe_target_dates,
     seconds_to_hours)
 
 
@@ -20,3 +24,16 @@ class TestHelpers(TestCase):
 
     def test_seconds_to_hours(self):
         self.assertEqual(seconds_to_hours(3600), 1.)
+
+
+class TestBumpSomedayMaybe(TestCase):
+    def test_bumper(self):
+        m = MilestoneFactory(
+            name="Someday/Maybe",
+            status="OPEN",
+            target_date=datetime.now().date())
+        bump_someday_maybe_target_dates()
+        m2 = Milestone.objects.get(mid=m.mid)
+        self.assertEqual(
+            m2.target_date,
+            (datetime.now() + timedelta(weeks=52)).date())


### PR DESCRIPTION
Someday/Maybe milestones are special ones that contain items that
we don't want to lose, but that don't show up on schedules.

It's a bit of a hassle when they finally come due though. Not a big deal,
but it means they show up on the dashboard, need to be adjusted, etc.

This just runs every day at midnight and pushes any that are coming up within
a month a full year into the future. This should be good enough
to keep them from really ending up on anyone's radar.
