### PR TITLE
Made tab views for outstanding items and overdue milestones

### DIFF
--- a/dmt/templates/main/index.html
+++ b/dmt/templates/main/index.html
@@ -24,31 +24,6 @@
 {% else %}
   {% pmtuser as pmt_user %}
 
-{% with pmt_user.passed_open_milestones as overdue_milestones %}
-{% if overdue_milestones %}
-<div class="panel panel-danger">
-<div class="panel-heading">Your Overdue Milestones</div>
-<table class="table table-striped table-condensed">
-<tr>
-	<th>Target Date</th>
-	<th>Project</th>
-	<th>Milestone</th>
-	<th></th>
-</tr>
-{% for m in overdue_milestones %}
-<tr>
-	<td>{{m.target_date|timesince}} ago</td>
-	<td><a href="{{m.project.get_absolute_url}}">{{m.project.name}}</a></td>
-	<td><a href="{{m.get_absolute_url}}">{{m.name}}</a></td>
-	<td>{{m.active_items.count}} item{{m.active_items.count|pluralize}} blocking</td>
-</tr>
-{% endfor %}
-</table>
-</div>
-{% endif %}
-{% endwith %}
-
-
   <div class="object-action-set clearfix">
     <ul>
       <li class="object-action" title="Add tracker">
@@ -67,6 +42,47 @@
     </ul>
   </div><!-- ./object-action-set -->
 
+
+
+
+<ul class="nav nav-tabs project-tabs">
+{% with pmt_user.passed_open_milestones as overdue_milestones %}
+{% if overdue_milestones %}
+  <li class="active"><a href="#overdue-milestones" data-toggle="tab">Overdue Milestones</a></li>
+{% endif %}
+{% endwith %}
+  <li><a href="#outstanding-items" data-toggle="tab">Outstanding Items</a></li>
+</ul>
+
+<div class="tab-content">
+
+{% with pmt_user.passed_open_milestones as overdue_milestones %}
+{% if overdue_milestones %}
+<div class="tab-pane fade in active" id="overdue-milestones">
+<div class="panel panel-danger">
+<div class="panel-heading"><b><span class="glyphicon glyphicon-exclamation-sign"></span> You have overdue milestones</b></div>
+<table class="table table-striped table-condensed">
+<tr>
+	<th>Target Date</th>
+	<th>Project</th>
+	<th>Milestone</th>
+	<th></th>
+</tr>
+{% for m in overdue_milestones %}
+<tr>
+	<td>{{m.target_date|timesince}} ago</td>
+	<td><a href="{{m.project.get_absolute_url}}">{{m.project.name}}</a></td>
+	<td><a href="{{m.get_absolute_url}}">{{m.name}}</a></td>
+	<td>{{m.active_items.count}} item{{m.active_items.count|pluralize}} blocking</td>
+</tr>
+{% endfor %}
+</table>
+</div>
+</div>
+{% endif %}
+{% endwith %}
+
+<div class="tab-pane fade" id="outstanding-items">
 
 <div class="modal fade" id="add-tracker" tabindex="-1" role="dialog" aria-labelledby="add-tracker-label" aria-hidden="true">
     <div class="modal-dialog">
@@ -231,6 +247,9 @@
     You need to <a href="/claim/">claim your account</a> first.
 </div>
 {% endif %}
+</div>
+</div>
+
 {% endif %}
 
 {% endblock %}

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -793,7 +793,7 @@ background: #000;
 }
 
 .progressbar-set {
-  margin: 0;
+  margin: 60px 0 0 0;
   padding: 0;
   border: 0;
   height: 25px;


### PR DESCRIPTION
I separated the Overdue Milestones and Outstanding Items to tab views and made Overdue Milestones the default tab.

Having both on the same page is confusing, and when the Overdue Milestones gets long, that table pushes the Items too far down. Toggle hide/show for Overdue Milestones without state-saving is just as irksome as tab view, because user will have to keep closing the table to hide.

With the Overdue Milestones tab view as default will make people address the issue and hopefully deal with it to make the tab go away. This is a more effective habit changer.
