### PR TITLE
Fix jQuery tooltip blocking title attribute for action item links

### DIFF
--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -795,7 +795,6 @@ function s3_upload() {
 <script>
 jQuery(document).ready(function() {
     jQuery('.breadcrumb-item').tooltip();
-    jQuery('.item-action-link').tooltip();
 });
 </script>
 


### PR DESCRIPTION
jQuery tooltip wasn't doing anything except blocking the title
attribute for action item links -- preventing me from seeing what
the buttons are when my browser window is less than 800px wide or
whatever, so I removed it.
