### PR TITLE
deleted My Groups link from navigation

### DIFF
--- a/dmt/templates/base.html
+++ b/dmt/templates/base.html
@@ -151,7 +151,6 @@
               <span class="hidden-sm">Users/Groups</span> <span class="caret"></span>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="http://pmt.ccnmtl.columbia.edu/home.pl?mode=my_groups" class="old-pmt"><span class="glyphicon glyphicon-arrow-left"></span> My groups</a></li>
                 <li><a href="{% url 'group_list' %}">All groups</a></li>
                 <li><a href="{% url 'user_list' %}?status=active">All users</a></li>
               </ul>


### PR DESCRIPTION
Make sense to not have a dedicated page on this because the list of groups a user belongs to is already in the profile page. I'm waiting for response from Lucy/Michelle on the other 3 (old PMT) links on the global nav bar.
