### PR TITLE
rename User to UserProfile

### DIFF
--- a/dmt/api/serializers.py
+++ b/dmt/api/serializers.py
@@ -1,5 +1,5 @@
 from dmt.main.models import (
-    Client, Item, Milestone, Notify, Project, User
+    Client, Item, Milestone, Notify, Project, UserProfile
 )
 
 from rest_framework import serializers
@@ -64,7 +64,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
-        model = User
+        model = UserProfile
         fields = ('username', 'fullname', 'email', 'status',
                   'type', 'title', 'phone', 'bio', 'photo_url',
                   'photo_width', 'photo_height', 'campus',

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -11,7 +11,8 @@ from simpleduration import Duration, InvalidDuration
 from datetime import datetime, timedelta
 
 from dmt.claim.models import Claim
-from dmt.main.models import Client, Item, Milestone, Notify, Project, User
+from dmt.main.models import (
+    Client, Item, Milestone, Notify, Project, UserProfile)
 from dmt.main.utils import new_duration
 
 from .serializers import (
@@ -55,7 +56,7 @@ class GitUpdateView(View):
         item = get_object_or_404(Item, iid=iid)
         email = request.POST.get('email', None)
         email = normalize_email(email)
-        user = get_object_or_404(User, email=email)
+        user = get_object_or_404(UserProfile, email=email)
         status = request.POST.get('status', '')
         resolve_time = request.POST.get('resolve_time', '')
         comment = request.POST.get('comment', '')
@@ -224,5 +225,5 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
 
 class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
+    queryset = UserProfile.objects.all()
     serializer_class = UserSerializer

--- a/dmt/claim/models.py
+++ b/dmt/claim/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User as DjangoUser
-from dmt.main.models import User as PMTUser
+from dmt.main.models import UserProfile as PMTUser
 
 
 class Claim(models.Model):

--- a/dmt/main/forms.py
+++ b/dmt/main/forms.py
@@ -1,7 +1,7 @@
 import re
 from django import forms
 from django.forms import ModelForm, TextInput
-from .models import StatusUpdate, Node, User, Project, Milestone, Item
+from .models import StatusUpdate, Node, UserProfile, Project, Milestone, Item
 
 
 class StatusUpdateForm(ModelForm):
@@ -18,7 +18,7 @@ class NodeUpdateForm(ModelForm):
 
 class UserUpdateForm(ModelForm):
     class Meta:
-        model = User
+        model = UserProfile
         fields = ["fullname", "email", "type", "title", "phone",
                   "bio", "photo_url", "photo_width", "photo_height",
                   "campus", "building", "room"]

--- a/dmt/main/migrations/0002_auto_20141219_1741.py
+++ b/dmt/main/migrations/0002_auto_20141219_1741.py
@@ -1,0 +1,19 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name='User',
+            new_name='UserProfile',
+        ),
+    ]

--- a/dmt/main/migrations/0003_auto_20141219_1745.py
+++ b/dmt/main/migrations/0003_auto_20141219_1745.py
@@ -1,0 +1,99 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0002_auto_20141219_1741'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ingroup',
+            name='grp',
+            field=models.ForeignKey(related_name='group_members', db_column=b'grp', to='main.UserProfile'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='item',
+            name='assigned_to',
+            field=models.ForeignKey(related_name='assigned_items', db_column=b'assigned_to', to='main.UserProfile'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='item',
+            name='owner',
+            field=models.ForeignKey(related_name='owned_items', db_column=b'owner', to='main.UserProfile'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='notify',
+            name='item',
+            field=models.ForeignKey(related_name='notifies', db_column=b'iid', to='main.Item'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='area',
+            field=models.CharField(max_length=100, verbose_name=b'Discipline', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='distrib',
+            field=models.CharField(max_length=20, verbose_name=b'Distribution', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='entry_rel',
+            field=models.BooleanField(default=False, verbose_name=b'Released'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='eval_url',
+            field=models.CharField(max_length=255, verbose_name=b'Evaluation URL', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='info_url',
+            field=models.CharField(max_length=255, verbose_name=b'Information URL', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='name',
+            field=models.CharField(max_length=255, verbose_name=b'Project name'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='poster',
+            field=models.BooleanField(default=False, verbose_name=b'Poster project'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='projnum',
+            field=models.IntegerField(null=True, verbose_name=b'Project number', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='pub_view',
+            field=models.BooleanField(default=False, verbose_name=b'PMT View'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='url',
+            field=models.CharField(max_length=255, verbose_name=b'Project URL', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -16,7 +16,7 @@ import re
 import textwrap
 
 
-class User(models.Model):
+class UserProfile(models.Model):
     username = models.CharField(max_length=32, primary_key=True)
     fullname = models.CharField(max_length=128, blank=True)
     email = models.CharField(max_length=32)
@@ -326,7 +326,7 @@ class Project(models.Model):
     name = models.CharField("Project name", max_length=255)
     projnum = models.IntegerField("Project number", null=True, blank=True)
     pub_view = models.BooleanField("PMT View", default=False)
-    caretaker = models.ForeignKey(User, db_column='caretaker')
+    caretaker = models.ForeignKey(UserProfile, db_column='caretaker')
     description = models.TextField(blank=True)
     url = models.CharField("Project URL", max_length=255, blank=True)
     info_url = models.CharField("Information URL", max_length=255, blank=True)
@@ -419,7 +419,7 @@ class Project(models.Model):
     def all_users_not_in_project(self):
         already_in = set([w.username
                           for w in WorksOn.objects.filter(project=self)])
-        all_users = set(User.objects.filter(status='active'))
+        all_users = set(UserProfile.objects.filter(status='active'))
         return sorted(list(all_users - already_in),
                       key=lambda x: x.fullname.lower())
 
@@ -708,7 +708,7 @@ class Document(models.Model):
     url = models.CharField(max_length=256, blank=True)
     description = models.TextField(blank=True)
     version = models.CharField(max_length=16, blank=True)
-    author = models.ForeignKey(User, db_column='author')
+    author = models.ForeignKey(UserProfile, db_column='author')
     last_mod = models.DateTimeField(null=True, blank=True)
 
     class Meta:
@@ -810,9 +810,9 @@ class Item(models.Model):
     type = models.CharField(
         max_length=12,
         choices=[('bug', 'bug'), ('action item', 'action item')])
-    owner = models.ForeignKey(User, db_column='owner',
+    owner = models.ForeignKey(UserProfile, db_column='owner',
                               related_name='owned_items')
-    assigned_to = models.ForeignKey(User, db_column='assigned_to',
+    assigned_to = models.ForeignKey(UserProfile, db_column='assigned_to',
                                     related_name='assigned_items')
     title = models.CharField(max_length=255)
     milestone = models.ForeignKey(Milestone, db_column='mid')
@@ -1165,7 +1165,7 @@ class HistoryEvent(HistoryItem):
         return self._get_comment().comment
 
     def user(self):
-        return User.objects.get(username=self._get_comment().username)
+        return UserProfile.objects.get(username=self._get_comment().username)
 
 
 class HistoryComment(HistoryItem):
@@ -1179,7 +1179,7 @@ class HistoryComment(HistoryItem):
         return self.c.comment
 
     def user(self):
-        return User.objects.get(username=self.c.username)
+        return UserProfile.objects.get(username=self.c.username)
 
 
 class Notify(models.Model):
@@ -1187,7 +1187,7 @@ class Notify(models.Model):
                              null=False,
                              db_column='iid',
                              related_name='notifies')
-    username = models.ForeignKey(User, db_column='username')
+    username = models.ForeignKey(UserProfile, db_column='username')
 
     class Meta:
         db_table = u'notify'
@@ -1208,7 +1208,7 @@ class Client(models.Model):
     add_affiliation = models.CharField(max_length=255, blank=True)
     phone = models.CharField(max_length=32, blank=True)
     email = models.CharField(max_length=128, blank=True)
-    contact = models.ForeignKey(User, null=True, db_column='contact',
+    contact = models.ForeignKey(UserProfile, null=True, db_column='contact',
                                 blank=True)
     comments = models.TextField(blank=True)
     status = models.CharField(max_length=16, blank=True)
@@ -1240,7 +1240,7 @@ class Node(models.Model):
     nid = models.AutoField(primary_key=True)
     subject = models.CharField(max_length=256, blank=True)
     body = models.TextField(blank=True)
-    author = models.ForeignKey(User, db_column='author')
+    author = models.ForeignKey(UserProfile, db_column='author')
     reply_to = models.IntegerField(null=True, blank=True)
     replies = models.IntegerField(null=True, blank=True)
     type = models.CharField(max_length=8)
@@ -1303,7 +1303,7 @@ class Node(models.Model):
 
 
 class WorksOn(models.Model):
-    username = models.ForeignKey(User, db_column='username')
+    username = models.ForeignKey(UserProfile, db_column='username')
     project = models.ForeignKey(Project, db_column='pid')
     auth = models.CharField(max_length=16)
 
@@ -1330,16 +1330,16 @@ class Events(models.Model):
 
 class NotifyProject(models.Model):
     pid = models.ForeignKey(Project, db_column='pid')
-    username = models.ForeignKey(User, db_column='username')
+    username = models.ForeignKey(UserProfile, db_column='username')
 
     class Meta:
         db_table = u'notify_project'
 
 
 class InGroup(models.Model):
-    grp = models.ForeignKey(User, db_column='grp',
+    grp = models.ForeignKey(UserProfile, db_column='grp',
                             related_name='group_members')
-    username = models.ForeignKey(User, null=True,
+    username = models.ForeignKey(UserProfile, null=True,
                                  db_column='username', blank=True)
 
     @staticmethod
@@ -1364,7 +1364,7 @@ class ProjectClient(models.Model):
 
 class ActualTime(models.Model):
     item = models.ForeignKey(Item, null=False, db_column='iid')
-    resolver = models.ForeignKey(User, db_column='resolver')
+    resolver = models.ForeignKey(UserProfile, db_column='resolver')
     actual_time = IntervalField(null=True, blank=True)
     completed = models.DateTimeField(primary_key=True)
 
@@ -1395,7 +1395,7 @@ class Attachment(models.Model):
     type = models.CharField(max_length=8, blank=True)
     url = models.CharField(max_length=256, blank=True)
     description = models.TextField(blank=True)
-    author = models.ForeignKey(User, db_column='author')
+    author = models.ForeignKey(UserProfile, db_column='author')
     last_mod = models.DateTimeField(null=True, blank=True)
 
     class Meta:
@@ -1429,7 +1429,7 @@ class Comment(models.Model):
         ordering = ['add_date_time', ]
 
     def user(self):
-        return User.objects.get(username=self.username)
+        return UserProfile.objects.get(username=self.username)
 
     def user_is_owner(self, user):
         """Return True if user is comment owner."""
@@ -1438,7 +1438,7 @@ class Comment(models.Model):
 
 class StatusUpdate(models.Model):
     project = models.ForeignKey(Project)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(UserProfile)
     added = models.DateTimeField(auto_now_add=True)
     body = models.TextField(blank=True, default=u"")
 

--- a/dmt/main/tests/factories.py
+++ b/dmt/main/tests/factories.py
@@ -1,13 +1,13 @@
 import factory
 from datetime import datetime, timedelta
 from django.utils.timezone import utc
-from dmt.main.models import User, Project, Milestone, Item
+from dmt.main.models import UserProfile, Project, Milestone, Item
 from dmt.main.models import Comment, Events, Node, ActualTime, StatusUpdate
 from dmt.main.models import Client, Attachment, Notify, InGroup
 
 
 class UserFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = User
+    FACTORY_FOR = UserProfile
     username = factory.Sequence(lambda n: 'user{0}'.format(n))
     fullname = factory.Sequence(lambda n: 'User {0}'.format(n))
     email = factory.Sequence(lambda n: 'user{0}@columbia.edu'.format(n))

--- a/dmt/main/tests/support/mixins.py
+++ b/dmt/main/tests/support/mixins.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
 from dmt.claim.models import Claim
-from dmt.main.models import User as PMTUser
+from dmt.main.models import UserProfile as PMTUser
 
 
 class LoggedInTestMixin(TestCase):

--- a/dmt/report/models.py
+++ b/dmt/report/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from dmt.main.models import ActualTime, InGroup, Project, User
+from dmt.main.models import ActualTime, InGroup, Project, UserProfile
 
 
 class ActiveProjectsCalculator(object):
@@ -24,8 +24,8 @@ class StaffReportCalculator(object):
         user_data = []
         for grp in self.groups:
             try:
-                group_user = User.objects.get(username="grp_" + grp)
-            except User.DoesNotExist:
+                group_user = UserProfile.objects.get(username="grp_" + grp)
+            except UserProfile.DoesNotExist:
                 continue
 
             for user in group_user.users_in_group():
@@ -52,7 +52,7 @@ class StaffReportCalculator(object):
 class WeeklySummaryReportCalculator(object):
     def __init__(self, groups):
         groupnames = ['grp_' + x for x in groups]
-        self.groups = User.objects.filter(username__in=groupnames)
+        self.groups = UserProfile.objects.filter(username__in=groupnames)
         self.groupnames = [InGroup.verbose_name(x.fullname)
                            for x in self.groups]
 

--- a/dmt/report/tests/test_views.py
+++ b/dmt/report/tests/test_views.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from dmt.main.models import User as PMTUser
+from dmt.main.models import UserProfile as PMTUser
 from dmt.main.models import InGroup
 from dmt.main.tests.factories import ItemFactory, MilestoneFactory
 from dmt.main.tests.support.mixins import LoggedInTestMixin

--- a/dmt/report/views.py
+++ b/dmt/report/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView, View
 from dmt.claim.models import Claim
-from dmt.main.models import User, Item, Milestone, Project
+from dmt.main.models import UserProfile, Item, Milestone, Project
 from dmt.main.views import LoggedInMixin
 from dmt.main.utils import interval_to_hours
 from .models import (
@@ -102,7 +102,7 @@ class UserYearlyView(LoggedInMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UserYearlyView, self).get_context_data(**kwargs)
         username = kwargs['pk']
-        user = get_object_or_404(User, username=username)
+        user = get_object_or_404(UserProfile, username=username)
         now = datetime.today()
         interval_start = now + timedelta(days=-365)
         interval_end = now
@@ -121,7 +121,7 @@ class UserWeeklyView(LoggedInMixin, PrevNextWeekMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UserWeeklyView, self).get_context_data(**kwargs)
         username = kwargs['pk']
-        user = get_object_or_404(User, username=username)
+        user = get_object_or_404(UserProfile, username=username)
         data = user.weekly_report(self.week_start, self.week_end)
         data.update(dict(u=user, now=self.now,
                          week_start=self.week_start.date,


### PR DESCRIPTION
The first step laid out in my overarching plan to clean up and merge user models (see https://pmt.ccnmtl.columbia.edu/forum/4532/)

This one just renames (on the code side only) `dmt.main.models.User` to `dmt.main.models.UserProfile`, since we'll eventually be using that model as a regular Django UserProfile.
