### PR TITLE
Add external action item API - PMT #96873

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -7,7 +7,7 @@ class SafeOriginAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         origin = getattr(request.META, 'HTTP_HOST')
 
-        if not origin.endswith('.ccnmtl.columbia.edu'):
+        if not origin.endswith('.columbia.edu'):
             raise exceptions.AuthenticationFailed('Unrecognized origin')
 
         # Any request using this auth type is considered anonymous

--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import authentication
+from rest_framework import exceptions
+
+
+class SafeOriginAuthentication(authentication.BaseAuthentication):
+    def authenticate(self, request):
+        origin = getattr(request.META, 'HTTP_HOST')
+
+        if not origin.endswith('.ccnmtl.columbia.edu'):
+            raise exceptions.AuthenticationFailed('Unrecognized origin')
+
+        # Any request using this auth type is considered anonymous
+        return (AnonymousUser(), None)

--- a/dmt/api/serializers.py
+++ b/dmt/api/serializers.py
@@ -16,7 +16,7 @@ class ClientSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class ItemSerializer(serializers.HyperlinkedModelSerializer):
-    notifies = serializers.RelatedField(many=True)
+    notifies = serializers.StringRelatedField(many=True)
 
     class Meta:
         model = Item
@@ -39,8 +39,8 @@ class MilestoneSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class NotifySerializer(serializers.Serializer):
-    item = serializers.RelatedField()
-    username = serializers.RelatedField()
+    item = serializers.PrimaryKeyRelatedField(read_only=True)
+    username = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Notify
@@ -50,7 +50,9 @@ class NotifySerializer(serializers.Serializer):
 class ProjectSerializer(serializers.HyperlinkedModelSerializer):
     milestone_set = serializers.HyperlinkedRelatedField(
         many=True,
-        view_name='milestone-detail')
+        view_name='milestone-detail',
+        read_only=True
+    )
 
     class Meta:
         model = Project

--- a/dmt/api/tests/test_views.py
+++ b/dmt/api/tests/test_views.py
@@ -264,8 +264,28 @@ class ExternalAddItemTests(APITestCase):
         self.assertEqual(r.data.get('type'), 'action item')
         self.assertTrue(self.owner.username in r.data.get('owner'))
         self.assertTrue(self.owner.username in r.data.get('assigned_to'))
+        self.assertTrue(unicode(self.milestone.pk) in r.data.get('milestone'))
         self.assertEqual(r.data.get('estimated_time'), '1:00:00')
         self.assertEqual(r.data.get('target_date'), self.target_date)
+
+    def test_post_redirects_client(self):
+        redirect_url = 'http://example.com'
+
+        r = self.client.post(reverse('external-add-item'), {
+            'title': self.title,
+            'email': self.email,
+            'name': self.name,
+            'pid': unicode(self.project.pk),
+            'mid': unicode(self.milestone.pk),
+            'type': 'action item',
+            'owner': self.owner.username,
+            'assigned_to': self.owner.username,
+            'estimated_time': self.estimated_time,
+            'target_date': self.target_date,
+            'redirect_url': redirect_url,
+        })
+        self.assertEqual(r.status_code, 302)
+        self.assertRedirects(r, redirect_url, fetch_redirect_response=False)
 
 
 class NotifyTests(APITestCase):

--- a/dmt/api/tests/test_views.py
+++ b/dmt/api/tests/test_views.py
@@ -8,10 +8,12 @@ from rest_framework.test import APITestCase
 
 from dmt.claim.models import Claim, PMTUser
 from dmt.main.models import ActualTime, Item, Notify
-from dmt.main.tests.factories import MilestoneFactory, ClientFactory
+from dmt.main.tests.factories import (
+    ClientFactory, MilestoneFactory, ProjectFactory, UserFactory
+)
 from dmt.main.tests.factories import ItemFactory, NotifyFactory
 
-from ..serializers import ItemSerializer
+from dmt.api.serializers import ItemSerializer
 
 
 class AddTrackerViewTest(TestCase):
@@ -227,6 +229,43 @@ class ItemTests(APITestCase):
 
         usernames = [n.lower() for n in r.data['notifies']]
         self.assertIn(self.pu.username.lower(), usernames)
+
+
+class ExternalAddItemTests(APITestCase):
+    def setUp(self):
+        self.title = 'Test item title'
+        self.email = 'submission_email@example.com'
+        self.name = 'Item Submitter'
+        self.owner = UserFactory()
+        self.project = ProjectFactory()
+        self.milestone = MilestoneFactory(project=self.project)
+        self.estimated_time = '1h'
+        self.target_date = '2015-01-01'
+
+    def test_post_creates_action_item(self):
+        r = self.client.post(reverse('external-add-item'), {
+            'title': self.title,
+            'email': self.email,
+            'name': self.name,
+            'pid': unicode(self.project.pk),
+            'mid': unicode(self.milestone.pk),
+            'type': 'action item',
+            'owner': self.owner.username,
+            'assigned_to': self.owner.username,
+            'estimated_time': self.estimated_time,
+            'target_date': self.target_date,
+        })
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data.get('title'), self.title)
+        self.assertTrue(
+            'Submitted by Item Submitter <submission_email@example.com>' in
+            r.data.get('description')
+        )
+        self.assertEqual(r.data.get('type'), 'action item')
+        self.assertTrue(self.owner.username in r.data.get('owner'))
+        self.assertTrue(self.owner.username in r.data.get('assigned_to'))
+        self.assertEqual(r.data.get('estimated_time'), '1:00:00')
+        self.assertEqual(r.data.get('target_date'), self.target_date)
 
 
 class NotifyTests(APITestCase):

--- a/dmt/api/urls.py
+++ b/dmt/api/urls.py
@@ -2,13 +2,14 @@ from django.conf.urls import include, patterns, url
 
 from rest_framework import routers
 
-from .views import (
+from dmt.api.views import (
     AddTrackerView,
     ItemHoursView, GitUpdateView,
     UserViewSet, ProjectMilestoneList,
     ClientViewSet, ProjectViewSet,
     MilestoneViewSet, ItemViewSet,
-    MilestoneItemList, NotifyView
+    MilestoneItemList, NotifyView,
+    ExternalAddItemView
 )
 
 router = routers.DefaultRouter()
@@ -31,4 +32,6 @@ urlpatterns = patterns(
     (r'^trackers/add/', AddTrackerView.as_view()),
     (r'^items/(?P<pk>\d+)/hours/$', ItemHoursView.as_view()),
     (r'^git/$', GitUpdateView.as_view()),
+    url(r'^external_add_item/$', ExternalAddItemView.as_view(),
+        name='external-add-item'),
 )

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -487,6 +487,7 @@ class Project(models.Model):
         item.add_project_notification()
         item.update_email("%s added\n\n%s" % (type, description), owner)
         milestone.update_milestone()
+        return item
 
     def recent_forum_posts(self, count=10):
         return self.node_set.all()[:count]

--- a/dmt/main/tests/factories.py
+++ b/dmt/main/tests/factories.py
@@ -7,7 +7,9 @@ from dmt.main.models import Client, Attachment, Notify, InGroup
 
 
 class UserFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = UserProfile
+    class Meta:
+        model = UserProfile
+
     username = factory.Sequence(lambda n: 'user{0}'.format(n))
     fullname = factory.Sequence(lambda n: 'User {0}'.format(n))
     email = factory.Sequence(lambda n: 'user{0}@columbia.edu'.format(n))
@@ -16,7 +18,9 @@ class UserFactory(factory.DjangoModelFactory):
 
 
 class ProjectFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Project
+    class Meta:
+        model = Project
+
     pid = factory.Sequence(lambda n: n)
     name = factory.Sequence(lambda n: 'Test Project {0}'.format(n))
     pub_view = True
@@ -24,7 +28,9 @@ class ProjectFactory(factory.DjangoModelFactory):
 
 
 class MilestoneFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Milestone
+    class Meta:
+        model = Milestone
+
     mid = factory.Sequence(lambda n: n)
     project = factory.SubFactory(ProjectFactory)
     name = factory.Sequence(lambda n: 'Test Milestone {0}'.format(n))
@@ -33,7 +39,9 @@ class MilestoneFactory(factory.DjangoModelFactory):
 
 
 class ItemFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Item
+    class Meta:
+        model = Item
+
     iid = factory.Sequence(lambda n: n)
     type = "bug"
     owner = factory.SubFactory(UserFactory)
@@ -45,13 +53,17 @@ class ItemFactory(factory.DjangoModelFactory):
 
 
 class NotifyFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Notify
+    class Meta:
+        model = Notify
+
     item = factory.SubFactory(ItemFactory)
     username = factory.SubFactory(UserFactory)
 
 
 class EventFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Events
+    class Meta:
+        model = Events
+
     eid = factory.Sequence(lambda n: n)
     status = "OPEN"
     event_date_time = datetime(2020, 12, 1).replace(tzinfo=utc)
@@ -59,7 +71,9 @@ class EventFactory(factory.DjangoModelFactory):
 
 
 class CommentFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Comment
+    class Meta:
+        model = Comment
+
     cid = factory.Sequence(lambda n: n)
     comment = "a comment"
     add_date_time = datetime(2020, 12, 1).replace(tzinfo=utc)
@@ -69,7 +83,9 @@ class CommentFactory(factory.DjangoModelFactory):
 
 
 class NodeFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Node
+    class Meta:
+        model = Node
+
     nid = factory.Sequence(lambda n: n)
     added = datetime(2020, 12, 1).replace(tzinfo=utc)
     modified = datetime(2020, 12, 1).replace(tzinfo=utc)
@@ -77,7 +93,9 @@ class NodeFactory(factory.DjangoModelFactory):
 
 
 class ActualTimeFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = ActualTime
+    class Meta:
+        model = ActualTime
+
     item = factory.SubFactory(ItemFactory)
     resolver = factory.SubFactory(UserFactory)
     actual_time = timedelta(hours=1).total_seconds()
@@ -85,7 +103,9 @@ class ActualTimeFactory(factory.DjangoModelFactory):
 
 
 class ClientFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Client
+    class Meta:
+        model = Client
+
     client_id = factory.Sequence(lambda n: n)
     lastname = "clientlastname"
     firstname = "clientfirstname"
@@ -99,14 +119,18 @@ class ClientFactory(factory.DjangoModelFactory):
 
 
 class StatusUpdateFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = StatusUpdate
+    class Meta:
+        model = StatusUpdate
+
     project = factory.SubFactory(ProjectFactory)
     user = factory.SubFactory(UserFactory)
     body = "some text as a body"
 
 
 class AttachmentFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = Attachment
+    class Meta:
+        model = Attachment
+
     item = factory.SubFactory(ItemFactory)
     filename = "foo.jpg"
     title = "an attachment"
@@ -115,6 +139,8 @@ class AttachmentFactory(factory.DjangoModelFactory):
 
 
 class GroupFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = InGroup
+    class Meta:
+        model = InGroup
+
     grp = factory.SubFactory(UserFactory, grp=True)
     username = factory.SubFactory(UserFactory)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ logilab-astng==0.24.3
 astroid==1.2.1
 pylint==1.3.1
 six==1.8.0
-python-dateutil==2.2
+python-dateutil==2.4.0
 pytz==2014.7
 simpleduration==0.1.0
 factory_boy==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ BeautifulSoup==3.2.1
 lxml==3.2.3
 fuzzywuzzy==0.4.0
 sure==1.2.7
-ipython==0.13.2
+ipython==1.2.1
 ipdb==0.8
 isodate==0.5.0
 SPARQLWrapper==1.6.4
@@ -76,7 +76,7 @@ django-ga-context==0.1.0
 django-impersonate==0.9
 django-pgsql-interval-field==0.9.3
 django-filter==0.8
-djangorestframework==2.4.3
+djangorestframework==3.0.2
 django-taggit==0.12.1a
 django-templatetag-sugar==1.0
 django-taggit-templatetags==0.4.6dev


### PR DESCRIPTION
Right now it's secured by only allowing requests from domains that end
with ccnmtl.columbia.edu.

Once this is merged I'll update the URL here: https://github.com/ccnmtl/mediathread/blob/master/mediathread/main/views.py#L411 to http://pmt.ccnmtl.columbia.edu/drf/external_add_item/