### PR TITLE
Fix User, Project, and Client filters - PMT #98539

### DIFF
--- a/dmt/main/filters.py
+++ b/dmt/main/filters.py
@@ -1,0 +1,39 @@
+from django.db.models import Q
+from django_filters import (
+    CharFilter, FilterSet, ModelChoiceFilter, NumberFilter
+)
+
+from dmt.main.models import UserProfile
+
+
+class ClientFilter(FilterSet):
+    lastname = CharFilter(label='Last Name', lookup_type='icontains')
+    firstname = CharFilter(label='First Name', lookup_type='icontains')
+    department = CharFilter(lookup_type='icontains')
+    school = CharFilter(lookup_type='icontains')
+    email = CharFilter(lookup_type='icontains')
+    phone = CharFilter(label='Phone Number', lookup_type='icontains')
+    comments = CharFilter(lookup_type='icontains')
+    contact = ModelChoiceFilter(
+        queryset=UserProfile.objects.filter(
+            Q(status__iexact='active') & ~Q(username__startswith='grp_')
+        ))
+
+
+class ProjectFilter(FilterSet):
+    name = CharFilter(label='Project Name', lookup_type='icontains')
+    projnum = NumberFilter(label='Project Number')
+    caretaker = ModelChoiceFilter(
+        queryset=UserProfile.objects.filter(
+            Q(status__iexact='active') & ~Q(username__startswith='grp_')
+        ))
+    description = CharFilter(lookup_type='icontains')
+
+
+class UserFilter(FilterSet):
+    username = CharFilter(lookup_type='icontains')
+    fullname = CharFilter(label='Full Name', lookup_type='icontains')
+    email = CharFilter(lookup_type='icontains')
+    phone = CharFilter(label='Phone Number', lookup_type='icontains')
+    title = CharFilter(lookup_type='icontains')
+    bio = CharFilter(lookup_type='icontains')

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -130,7 +130,7 @@ class TestProjectViews(TestCase):
 
     def test_all_projects_page(self):
         p = ProjectFactory()
-        r = self.c.get("/project/")
+        r = self.c.get(reverse('project_list'))
         self.assertEqual(r.status_code, 200)
         self.assertTrue(p.name in r.content)
         self.assertTrue(p.get_absolute_url() in r.content)
@@ -1220,3 +1220,9 @@ class TestAddTrackersView(LoggedInTestMixin, TestCase):
         i = Item.objects.last()
         resolve_time = i.get_resolve_time()
         self.assertEqual(resolve_time, timedelta(0, 3600))
+
+
+class TestUserViews(LoggedInTestMixin, TestCase):
+    def test_user_list_page(self):
+        response = self.client.get(reverse('user_list'))
+        self.assertEqual(response.status_code, 200)

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -22,8 +22,9 @@ from dmt.main.models import (
     Comment, Project, Milestone, Item, InGroup, Node, UserProfile, Client,
     StatusUpdate, ActualTime, Notify, Attachment
 )
-from .models import interval_sum
-from .forms import (
+from dmt.main.models import interval_sum
+from dmt.main.filters import ClientFilter, ProjectFilter, UserFilter
+from dmt.main.forms import (
     ItemUpdateForm,
     ProjectCreateForm, StatusUpdateForm, NodeUpdateForm, UserUpdateForm,
     ProjectUpdateForm, MilestoneUpdateForm)
@@ -380,6 +381,7 @@ class IndexView(LoggedInMixin, TemplateView):
 
 
 class ClientListView(LoggedInMixin, FilterView):
+    filterset_class = ClientFilter
     model = Client
     paginate_by = 100
 
@@ -509,6 +511,7 @@ class ProjectCreateView(LoggedInMixin, CreateView):
 
 
 class ProjectListView(LoggedInMixin, FilterView):
+    filterset_class = ProjectFilter
     model = Project
 
 
@@ -608,6 +611,8 @@ class ProjectUpdateView(LoggedInMixin, UpdateView):
 
 
 class UserListView(LoggedInMixin, FilterView):
+    template_name = 'main/user_filter.html'
+    filterset_class = UserFilter
     model = UserProfile
 
     def get_queryset(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-impersonate==0.9
 django-pgsql-interval-field==0.9.3
-django-filter==0.8
+django-filter==0.9.1
 djangorestframework==2.4.3
 django-taggit==0.12.1a
 django-templatetag-sugar==1.0


### PR DESCRIPTION
Add custom filterset classes that change the lookup type on relevant
fields to 'icontains' instead of the default 'exact'.

I've also fixed a 500 error at the user list page (`/user/`) and added a test to prevent this.