### PR TITLE
Change HTTP_HOST to REMOTE_HOST, and properly auth

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -1,11 +1,17 @@
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import authentication
 from rest_framework import exceptions
+from rest_framework import permissions
+
+
+class IsAnonymous(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user.is_anonymous()
 
 
 class SafeOriginAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
-        origin = getattr(request.META, 'HTTP_HOST')
+        origin = request.META.get('REMOTE_HOST')
 
         if not origin.endswith('.columbia.edu'):
             raise exceptions.AuthenticationFailed('Unrecognized origin')

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -7,7 +7,6 @@ from django.views.generic import View
 from rest_framework import filters, generics, viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.permissions import AllowAny
 from simpleduration import Duration, InvalidDuration
 from datetime import datetime, timedelta
 from dateutil import parser
@@ -18,7 +17,7 @@ from dmt.main.models import (
 )
 from dmt.main.utils import new_duration
 
-from dmt.api.auth import SafeOriginAuthentication
+from dmt.api.auth import IsAnonymous, SafeOriginAuthentication
 from dmt.api.serializers import (
     ClientSerializer, ItemSerializer, MilestoneSerializer, NotifySerializer,
     ProjectSerializer, UserSerializer,
@@ -54,7 +53,7 @@ class ExternalAddItemView(APIView):
     For Mediathread, Edblogs, etc.
     """
     authentication_classes = (SafeOriginAuthentication,)
-    permission_classes = (AllowAny,)
+    permission_classes = (IsAnonymous,)
 
     def redirect_or_return_item(self, request, item, redirect_url, append_iid):
         if redirect_url:


### PR DESCRIPTION
`HTTP_HOST` is the hostname of the server, not the client. This fixes the
security mechanism.

Also, `AllowAny` was allowing a request even if it was not authenticated
with my specified custom auth. This change fixes that issue as well.