### PR TITLE
Correct safe origin auth again

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -1,20 +1,7 @@
-from django.contrib.auth.models import AnonymousUser
-from rest_framework import authentication
-from rest_framework import exceptions
 from rest_framework import permissions
 
 
-class IsAnonymous(permissions.BasePermission):
+class SafeOriginPermission(permissions.BasePermission):
     def has_permission(self, request, view):
-        return request.user.is_anonymous()
-
-
-class SafeOriginAuthentication(authentication.BaseAuthentication):
-    def authenticate(self, request):
         origin = request.META.get('REMOTE_HOST')
-
-        if not origin.endswith('.columbia.edu'):
-            raise exceptions.AuthenticationFailed('Unrecognized origin')
-
-        # Any request using this auth type is considered anonymous
-        return (AnonymousUser(), None)
+        return (origin and origin.endswith('.columbia.edu'))

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -17,7 +17,7 @@ from dmt.main.models import (
 )
 from dmt.main.utils import new_duration
 
-from dmt.api.auth import IsAnonymous, SafeOriginAuthentication
+from dmt.api.auth import SafeOriginPermission
 from dmt.api.serializers import (
     ClientSerializer, ItemSerializer, MilestoneSerializer, NotifySerializer,
     ProjectSerializer, UserSerializer,
@@ -52,8 +52,7 @@ class ExternalAddItemView(APIView):
 
     For Mediathread, Edblogs, etc.
     """
-    authentication_classes = (SafeOriginAuthentication,)
-    permission_classes = (IsAnonymous,)
+    permission_classes = (SafeOriginPermission,)
 
     def redirect_or_return_item(self, request, item, redirect_url, append_iid):
         if redirect_url:


### PR DESCRIPTION
My auth was still allowing requests to go through from domains outside
columbia.edu. I found out that all I need is a 'permission', not an
'authentication'.

This time I've put mock headers in the tests to make sure this is
working as intended.