### PR TITLE
Add HTTP_REFERER to external_add_item permissions

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -1,7 +1,12 @@
 from rest_framework import permissions
+from urlparse import urlparse
 
 
 class SafeOriginPermission(permissions.BasePermission):
     def has_permission(self, request, view):
+        safe_origin = '.columbia.edu'
         origin = request.META.get('REMOTE_HOST')
-        return (origin and origin.endswith('.columbia.edu'))
+        referrer = request.META.get('HTTP_REFERER')
+
+        return (origin and origin.endswith(safe_origin)) or \
+            (referrer and urlparse(referrer).netloc.endswith(safe_origin))


### PR DESCRIPTION
In many cases, we actually care about the client's HTTP_REFERER, not
it's REMOTE_HOST. This should fix the permission error when submitting
http://mediathread.ccnmtl.columbia.edu/contact/