### PR TITLE
put in CSRF middleware. fixes PMT #98700

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -79,6 +79,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = [
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -176,7 +176,6 @@
       {% endfor %}
       {% endif %}
       <form action="tag/" method="post">
-      
       <div class="input-group input-group-sm tag-form">
       <input class="form-control" type="text" placeholder="Add tags (comma or space separated)" name="tags" />
       <span class="input-group-btn"><input type="submit" value="Tag" class="btn btn-primary" /></span>


### PR DESCRIPTION
Basically all the AJAX functionality in the PMT is failing because the `csrftoken` cookie isn't getting set. This middleware is what does that.

Honestly, I'm not sure why it only recently broke things. I looked through the last few months of changes that touched `settings_shared.py` and didn't see any that removed that middleware, so it seems like everything should've been broken for a long time. Is it something that 1.7.2 was suddenly much more strict about?