### PR TITLE
Don't clear Project/Client UNI on success in add tracker form

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
     "preset": "google",
     "validateIndentation": 4,
-    "disallowTrailingWhitespace": true
+    "disallowTrailingWhitespace": true,
+    "validateJSDoc": {}
 }

--- a/media/js/src/forms/add_tracker_form.js
+++ b/media/js/src/forms/add_tracker_form.js
@@ -13,10 +13,17 @@ require([
             $.ajax({
                 type: 'POST',
                 url: '/api/1.0/trackers/add/',
-                data: {pid: pid, task: task, time: time, client: client,
-                      completed: completed},
+                data: {
+                    pid: pid,
+                    task: task,
+                    time: time,
+                    client: client,
+                    completed: completed
+                },
                 success: function(data, status) {
-                    return formUtils.onSuccess($form, data, status);
+                    return formUtils.onSuccess($form, data, status, [
+                        '#tracker-task-input', '#tracker-time-input'
+                    ]);
                 },
                 error: function(xhr, status, error) {
                     return formUtils.onError($form, xhr, status, error);

--- a/media/js/src/forms/utils.js
+++ b/media/js/src/forms/utils.js
@@ -1,4 +1,4 @@
-define([], function() {
+define(['underscore'], function(_) {
     var FormUtils = function() {};
 
     FormUtils.prototype.refreshTargetDate = function($selectEl, targetDates) {
@@ -21,8 +21,20 @@ define([], function() {
         }
     };
 
-    FormUtils.prototype.onSuccess = function($form, data, status) {
-        $form.find('input:visible').val('');
+    /**
+     * @param {array} clearSelectors - An optional argument that can
+     *   contain an array of selectors that the form clears on success.
+     *   If this argument isn't used, onSuccess defaults to clearing
+     *   every visible input in the form.
+     */
+    FormUtils.prototype.onSuccess = function(
+        $form, data, status, clearSelectors
+    ) {
+        if (_.isArray(clearSelectors)) {
+            $form.find(clearSelectors.join(', ')).val('');
+        } else {
+            $form.find('input:visible').val('');
+        }
 
         $form.find('.form-ajax-response').remove();
         $form.append(

--- a/media/js/src/main.js
+++ b/media/js/src/main.js
@@ -1,3 +1,15 @@
+require.config({
+    paths: {
+        // Major libraries
+        jquery: '../libs/jquery/jquery-min',
+        underscore: '../libs/underscore/underscore-min',
+        backbone: '../libs/backbone/backbone-min',
+
+        // Require.js plugins
+        text: '../libs/require/text'
+    }
+});
+
 require([
     // libs
     '../libs/jquery/jquery-min',


### PR DESCRIPTION
PMT #98221.

I had to tell jscs to ignore jsdoc validation - I don't know why it
considered my jsdoc to be an error.