### PR TITLE
An attempt to fix CSRF referer error

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -1,5 +1,12 @@
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import authentication
 from rest_framework import permissions
 from urlparse import urlparse
+
+
+class SafeOriginAuthentication(authentication.BaseAuthentication):
+    def authenticate(self, request):
+        return (AnonymousUser(), None)
 
 
 class SafeOriginPermission(permissions.BasePermission):

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -18,7 +18,7 @@ from dmt.main.models import (
 )
 from dmt.main.utils import new_duration
 
-from dmt.api.auth import SafeOriginPermission
+from dmt.api.auth import SafeOriginAuthentication, SafeOriginPermission
 from dmt.api.serializers import (
     ClientSerializer, ItemSerializer, MilestoneSerializer, NotifySerializer,
     ProjectSerializer, UserSerializer,
@@ -53,6 +53,7 @@ class ExternalAddItemView(APIView):
 
     For Mediathread, Edblogs, etc.
     """
+    authentication_classes = (SafeOriginAuthentication,)
     permission_classes = (SafeOriginPermission,)
 
     def redirect_or_return_item(self, request, item, redirect_url, append_iid):


### PR DESCRIPTION
I was getting this error from the mediathread contact form:

    CSRF Failed: Referer checking failed -
    https://mediathread.ccnmtl.columbia.edu/contact/ does not match
    https://pmt.ccnmtl.columbia.edu/.

Because SessionAuthentication is only intended to be used on systems all
on the same domain, I've defined a SafeOriginAuthentication that just
authenticates as an anonymous user.