### PR TITLE
User OneToOne

### DIFF
--- a/dmt/main/migrations/0004_userprofile_user.py
+++ b/dmt/main/migrations/0004_userprofile_user.py
@@ -1,0 +1,23 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('main', '0003_auto_20141219_1745'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='user',
+            field=models.OneToOneField(null=True, to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+    ]

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth.models import User
 from django.db import connection, models
 from django.db.models.aggregates import Sum
 from django.conf import settings
@@ -33,6 +34,7 @@ class UserProfile(models.Model):
     campus = models.TextField(blank=True)
     building = models.TextField(blank=True)
     room = models.TextField(blank=True)
+    user = models.OneToOneField(User, null=True)
 
     class Meta:
         db_table = u'users'

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -1124,6 +1124,7 @@ class CreateUserTest(TestCase):
         self.assertEqual(r.status_code, 302)
         u = PMTUser.objects.get(username='newuser')
         self.assertEqual(u.email, new_user.email)
+        self.assertEqual(u.user.id, new_user.id)
 
 
 class UserTest(TestCase):

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -575,6 +575,7 @@ class CreateUserView(View):
             email=request.user.email,
             status='active',
             password='nopassword',
+            user=request.user,
         )
         print "made a new user: %s" % u.username
         Claim.objects.create(


### PR DESCRIPTION
The next two steps of the plan laid out here: https://pmt.ccnmtl.columbia.edu/forum/4532/

* add a nullable OneToOne field mapping `dmt.main.models.UserProfile` to `django.contrib.auth.models.User` objects.
* when a new user is created, populate that field. (through the CreateUser view now, but will switch it over to a signal handler next).