### PR TITLE
Add IP Whitelisting for /external_add_item/ via local_settings - PMT #98821

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import authentication
 from rest_framework import permissions
@@ -10,10 +11,53 @@ class SafeOriginAuthentication(authentication.BaseAuthentication):
 
 
 class SafeOriginPermission(permissions.BasePermission):
+    """URL and IP whitelist permissions.
+
+    Put settings like this in your local_settings.py:
+
+    WHITELIST_ORIGIN_IPS = (
+        '128.59.222.80',  # selma.ccnmtl.columbia.edu
+    )
+
+    WHITELIST_ORIGIN_URLS = (
+        '.columbia.edu',
+    )
+    """
+
+    def _has_safe_remote_addr(self, remote_addr):
+        try:
+            return settings.WHITELIST_ORIGIN_IPS and \
+                (remote_addr in settings.WHITELIST_ORIGIN_IPS)
+        except NameError:
+            return False
+
+    def _has_safe_referrer(self, referrer):
+        try:
+            # .endswith checks each element of the WHITELIST_ORIGIN_URLS
+            # tuple
+            return referrer and \
+                urlparse(referrer).netloc.endswith(
+                    settings.WHITELIST_ORIGIN_URLS)
+        except NameError:
+            return False
+
+    def _has_safe_remote_host(self, remote_host):
+        try:
+            return remote_host and remote_host.endswith(
+                settings.WHITELIST_ORIGIN_URLS)
+        except NameError:
+            return False
+
     def has_permission(self, request, view):
-        safe_origin = '.columbia.edu'
-        origin = request.META.get('REMOTE_HOST')
+        remote_addr = request.META.get('REMOTE_ADDR')
+        remote_host = request.META.get('REMOTE_HOST')
         referrer = request.META.get('HTTP_REFERER')
 
-        return (origin and origin.endswith(safe_origin)) or \
-            (referrer and urlparse(referrer).netloc.endswith(safe_origin))
+        checks = [
+            self._has_safe_remote_addr(remote_addr),
+            self._has_safe_remote_host(remote_host),
+            self._has_safe_referrer(referrer),
+        ]
+
+        # Return True if any of the checks are True
+        return any(checks)

--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -33,6 +33,13 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
     }
     CELERY_ALWAYS_EAGER = True
 
+    WHITELIST_ORIGIN_IPS = (
+    )
+
+    WHITELIST_ORIGIN_URLS = (
+        '.columbia.edu',
+    )
+
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 NOSE_ARGS = [


### PR DESCRIPTION
The remote host wasn't getting through from a mediathread server-to-server POST request, but from my testing we can get the IP address with `request.META['REMOTE_ADDR']`.

As documented in `api/auth.py`, here's an idea of what to put in the `local_settings.py` for whitelisting:
```python
WHITELIST_ORIGIN_IPS = (
    '128.59.222.80',  # selma.ccnmtl.columbia.edu
)

WHITELIST_ORIGIN_URLS = (
    '.columbia.edu',
)
```