### PR TITLE
command to convert claims to direct links

### DIFF
--- a/dmt/main/management/commands/claims_to_links.py
+++ b/dmt/main/management/commands/claims_to_links.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from dmt.claim.models import Claim
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        """convert each Claim entry to a direct
+        OneToOne link"""
+
+        for c in Claim.objects.all():
+            user = c.django_user
+            profile = c.pmt_user
+            if profile.user is None:
+                user.userprofile = profile
+                user.save()


### PR DESCRIPTION
I originally wrote this as a proper data migration but found that the stripped down ORM that Django uses in migrations couldn't handle setting up the OneToOne between User and UserProfile because the primary key on our UserProfile isn't an integer field.

So... I converted it to just a command, which will need to be manually run on each instance. Not ideal, but I don't know what else to do.