### PR TITLE
improve deactiveate user feature

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -151,6 +151,14 @@ class UserProfile(models.Model):
             ).exclude(status='VERIFIED').select_related(
             'milestone', 'milestone__project')
 
+    def non_verified_assigned_items(self):
+        """ all items assigned to this user that
+        are OPEN, INPROGRESS, or RESOLVED"""
+        return Item.objects.filter(
+            assigned_to=self,
+            ).exclude(status='VERIFIED').select_related(
+            'milestone', 'milestone__project')
+
     def items(self):
         assigned = set(self.open_assigned_items())
         owned = set(self.resolved_owned_items())

--- a/dmt/templates/main/user_deactivate.html
+++ b/dmt/templates/main/user_deactivate.html
@@ -40,7 +40,7 @@
 {% endif %}
 
 {% if user.open_assigned_items %}
-<h2>Open items assigned to this user:</h2>
+<h2>Open and Resolved items assigned to this user:</h2>
 
 <p>These must be reassigned to someone else</p>
 
@@ -53,7 +53,7 @@
 	</tr>
 </thead>
 <tbody>
-{% for i in user.open_assigned_items %}
+{% for i in user.non_verified_assigned_items %}
 <tr>
 	<td><a href="{{i.get_absolute_url}}">{{i.title}}</a></td>
 	<td><a href="{{i.milestone.project.get_absolute_url}}">{{i.milestone.project.name}}</a></td>
@@ -71,11 +71,11 @@
 </table>
 
 {% else %}
-<p>There are no open items assigned to this user.</p>
+<p>There are no open/resolved items assigned to this user.</p>
 {% endif %}
 
 {% if user.non_verified_owned_items %}
-<h2>Resolved items owned by this user:</h2>
+<h2>Open and Resolved items owned by this user:</h2>
 
 <p>Ownership on these must be changed to someone else</p>
 
@@ -107,7 +107,7 @@
 </table>
 
 {% else %}
-<p>There are no resolved items owned by this user.</p>
+<p>There are no open/resolved items owned by this user.</p>
 {% endif %}
 
 


### PR DESCRIPTION
the old version was missing out on someday/maybe items
and on resolved (but not verified) items owned by the user.

When we're deactivating someone, we really need to make sure
that *all* items that they were responsible for that are
still active get reassigned.