### PR TITLE
Avoid requirejs caching - PMT #98758

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -147,6 +147,7 @@ if 'jenkins' in sys.argv:
     COMPRESS_ENABLED = False
 
 INTERNAL_IPS = ('127.0.0.1', )
+
 DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.version.VersionDebugPanel',
     'debug_toolbar.panels.timer.TimerDebugPanel',
@@ -156,6 +157,9 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.sql.SQLDebugPanel',
     'debug_toolbar.panels.signals.SignalDebugPanel',
 )
+DEBUG_TOOLBAR_CONFIG = {
+    'INSERT_BEFORE': '<span class="djdt-insert-here">',
+}
 
 STATSD_CLIENT = 'statsd.client'
 STATSD_PREFIX = 'dmt'

--- a/dmt/templates/base.html
+++ b/dmt/templates/base.html
@@ -45,6 +45,10 @@
 </head>
 <body{% block extraclass %}{% endblock %}>
 
+    <!-- insert django-debug-toolbar here because it needs to load
+         before require.js -->
+    <span class="djdt-insert-here"></span>
+
 {% block topnavbar %}
   <nav class="navbar navbar-default navbar-inverse navbar-dmt navbar-fixed-top" role="navigation">
     <div class="container container-theme">

--- a/media/js/src/main.js
+++ b/media/js/src/main.js
@@ -7,7 +7,8 @@ require.config({
 
         // Require.js plugins
         text: '../libs/require/text'
-    }
+    },
+    urlArgs: 'bust=' +  (new Date()).getTime()
 });
 
 require([


### PR DESCRIPTION
Adding the cache-buster on main.js introduced an error between requirejs and django-debug-toolbar, and loading django-debug-toolbar's JS before requirejs seems to fix the problem.

Require.js has gotten a lot of criticism for these causing these kinds of problems, and it is kind of a pain to work with (it demands [lots](https://github.com/emberjs/ember.js/issues/9879) [of](https://github.com/ccnmtl/django-pagetree/pull/14) [workarounds](https://github.com/django-debug-toolbar/django-debug-toolbar/issues/605)). But the more modern alternative that I know of - browserify - relies on node.js, and we'd be adding a build step and more complexity in the deployment process. These javascript module libraries often seem to cause more problems than they solve.

I think we should stick with require.js for now in DMT, but I don't think I'm going to use it for any new projects. For new projects, I think just managing the dependencies manually isn't too much of a hassle, e.g. in [ssnm.html](https://github.com/ccnmtl/worth2/blob/master/worth2/templates/ssnm/ssnm.html#L276).