### PR TITLE
Primary groups - PMT #95814

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ integration: ./ve/bin/python
 	npm test
 
 flake8: ./ve/bin/python
-	$(FLAKE8) $(APP) --max-complexity=7
+	$(FLAKE8) $(APP) --exclude=migrations --max-complexity=7
 
 runserver: ./ve/bin/python check
 	$(MANAGE) runserver

--- a/dmt/main/management/commands/assign_primary_groups.py
+++ b/dmt/main/management/commands/assign_primary_groups.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+from dmt.main.models import UserProfile, InGroup
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        """Give each user a primary group.
+
+        This command picks the first InGroup object associated with each
+        user and uses that as the primary group.
+
+        We will need to fine-tune the primary groups after running this
+        command, but this provides an alright default.
+        """
+
+        for up in UserProfile.objects.filter(status='active'):
+            groups = InGroup.objects.filter(username=up)
+            group = groups.first()
+            if (group is not None) and (up.primary_group is None):
+                grp = group.grp
+                up.primary_group = grp
+                up.save()

--- a/dmt/main/migrations/0007_userprofile_primary_group.py
+++ b/dmt/main/migrations/0007_userprofile_primary_group.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0006_remove_userprofile_password'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='primary_group',
+            field=models.ForeignKey(blank=True, to='main.UserProfile', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -35,6 +35,10 @@ class UserProfile(models.Model):
     building = models.TextField(blank=True)
     room = models.TextField(blank=True)
     user = models.OneToOneField(User)
+    primary_group = models.ForeignKey('UserProfile',
+                                      blank=True,
+                                      null=True,
+                                      limit_choices_to={'grp': True})
 
     class Meta:
         db_table = u'users'

--- a/dmt/templates/main/user_detail.html
+++ b/dmt/templates/main/user_detail.html
@@ -47,9 +47,22 @@
 {% if object.bio %}
 <dt>Bio</dt><dd>{{object.bio|markdown|emoji_replace}}</dd>
 {% endif %}
+
+
+<dt>Primary Group</dt>
+<dd>
+    {% if object.primary_group %}
+    <a href="{% url 'group_detail' object.primary_group.username %}"
+       >{{object.primary_group.group_fullname}}</a>
+    {% else %}
+    <em>Unassigned</em>
+    {% endif %}
+</dd>
+
+
 {% with object.user_groups as groups %}
 {% if groups %}
-<dt>Groups</dt><dd>
+<dt>Secondary Groups</dt><dd>
 {% for g in groups %}
 <a href="{% url 'group_detail' g.username %}">
     {{g.group_fullname}}</a>{% if not forloop.last %}, {% endif %}

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -32,8 +32,6 @@ from dmt.main.views import (
 )
 from dmt.main.feeds import ForumFeed, StatusUpdateFeed, ProjectFeed
 
-admin.autodiscover()
-
 redirect_after_logout = getattr(settings, 'LOGOUT_REDIRECT_URL', None)
 auth_urls = (r'^accounts/', include('django.contrib.auth.urls'))
 logout_page = (


### PR DESCRIPTION
As a preliminary for setting up primary groups for reporting, this adds a `primary_group` attribute on the UserProfile, and includes a command for populating that attribute with a group that each user belongs to.