### PR TITLE
data migration to populate foreign key fields pointing to User

### DIFF
--- a/dmt/main/migrations/0010_auto_20150126_0732.py
+++ b/dmt/main/migrations/0010_auto_20150126_0732.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def populate_caretaker(apps, schema_editor):
+    print "==== populate caretakers ===="
+    Project = apps.get_model("main", "Project")
+    for project in Project.objects.all():
+        if project.caretaker_user is None:
+            project.caretaker_user = project.caretaker.user
+            project.save()
+            print "updated project %s" % project.name
+
+
+def populate_owner_assigned(apps, schema_editor):
+    print "==== populate owner/assigned ===="
+    Item = apps.get_model("main", "Item")
+    for item in Item.objects.all():
+        if item.assigned_user is None:
+            item.assigned_user = item.assigned_to.user
+        if item.owner_user is None:
+            item.owner_user = item.owner.user
+        item.save()
+
+
+def populate_notify(apps, schema_editor):
+    print "=== populate notify ==="
+    Notify = apps.get_model("main", "Notify")
+    for n in Notify.objects.all():
+        if n.user is None:
+            n.user = n.username.user
+            n.save()
+
+
+def populate_client_contact(apps, schema_editor):
+    print "=== populate Client contacts ==="
+    Client = apps.get_model("main", "Client")
+    for c in Client.objects.all():
+        if c.user is None:
+            c.user = c.contact.user
+            c.save()
+
+
+def populate_author(apps, schema_editor):
+    print "=== populate authors ==="
+    Node = apps.get_model("main", "Node")
+    for n in Node.objects.all():
+        if n.user is None:
+            n.user = n.author.user
+            n.save()
+
+
+def populate_workson(apps, schema_editor):
+    print "=== populate workson ==="
+    WorksOn = apps.get_model("main", "WorksOn")
+    for w in WorksOn.objects.all():
+        if w.user is None:
+            w.user = w.username.user
+            w.save()
+
+
+def populate_actual_time(apps, schema_editor):
+    print "=== populate actual time ==="
+    ActualTime = apps.get_model("main", "ActualTime")
+    for a in ActualTime.objects.all():
+        if a.user is None:
+            a.user = a.resolver.user
+            a.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0009_auto_20150123_0904'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_caretaker),
+        migrations.RunPython(populate_owner_assigned),
+        migrations.RunPython(populate_notify),
+        migrations.RunPython(populate_client_contact),
+        migrations.RunPython(populate_author),
+        migrations.RunPython(populate_workson),
+        migrations.RunPython(populate_actual_time),
+    ]


### PR DESCRIPTION
Everyone working on the DMT should take note of this one.
The data migration has to update basically every row in some of the big tables
with 100,000+ rows. This means it's very slow. Running it locally on a copy
of the production database took over half an hour.

This means that the rolf pushes will probably break/timeout so they
will have to be manually pushed through.

It also means that when you run 'make migrate' on your development instance,
it could take a very long time. Shouldn't be a big deal, but don't do that
if you were planning on working on it in the next few minutes or something. Run
the migration before you step out for lunch, or in the background while you work
on a different project.