### PR TITLE
Add the markdown previewer to two more comment fields - PMT #98847

### DIFF
--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -316,8 +316,18 @@
 				<div class="form-group">
 					<div class="instructions"><span class="glyphicon glyphicon-question-sign"></span>
           For text formatting, please see the <a href="http://wiki.ccnmtl.columbia.edu/index.php/Markdown_syntax_cheat_sheet" target="_blank">Markdown cheat sheet</a> for syntax rules.</div>
-					<textarea name="comment" class="form-control" rows="5" placeholder="Comment..."></textarea>
+					<textarea name="comment" class="form-control"
+                              id="dmt-project-item-resolve-comment"
+                              rows="5" placeholder="Comment..."></textarea>
 				</div>
+
+                <div class="form-group">
+                    <div class="instructions">
+                        Comment preview:
+                    </div>
+                    <div class="dmt-markdown-project-item-resolve-preview dmt-markdown-preview"
+                         >Comment</div>
+                </div>
 
 				<div class="form-group">
 					<label for="resolve-time-input">Time</label>
@@ -349,8 +359,17 @@
       <div class="modal-body">
           <div class="form-group">
             <div class="instructions"><span class="glyphicon glyphicon-question-sign"></span>
-                        For text formatting, please see the <a href="http://wiki.ccnmtl.columbia.edu/index.php/Markdown_syntax_cheat_sheet" target="_blank">Markdown cheat sheet</a> for syntax rules.</div>
-              <textarea name="comment" class="form-control" rows="5" placeholder="Comment..."></textarea>
+                For text formatting, please see the <a href="http://wiki.ccnmtl.columbia.edu/index.php/Markdown_syntax_cheat_sheet" target="_blank">Markdown cheat sheet</a> for syntax rules.</div>
+            <textarea name="comment" class="form-control"
+                      id="dmt-project-item-inprogress-comment"
+                      rows="5" placeholder="Comment..."></textarea>
+          </div>
+          <div class="form-group">
+              <div class="instructions">
+                  Comment preview:
+              </div>
+              <div class="dmt-markdown-project-item-inprogress-preview dmt-markdown-preview"
+                   >Comment</div>
           </div>
           <div class="form-group">
               <label for="progress-time-input">Time</label>

--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -316,10 +316,10 @@
 				<div class="form-group">
 					<div class="instructions"><span class="glyphicon glyphicon-question-sign"></span>
           For text formatting, please see the <a href="http://wiki.ccnmtl.columbia.edu/index.php/Markdown_syntax_cheat_sheet" target="_blank">Markdown cheat sheet</a> for syntax rules.</div>
-					<textarea name="comment" class="form-control"
+                    <textarea name="comment" class="form-control"
                               id="dmt-project-item-resolve-comment"
                               rows="5" placeholder="Comment..."></textarea>
-				</div>
+                </div>
 
                 <div class="form-group">
                     <div class="instructions">

--- a/media/js/src/forms/add_time_form.js
+++ b/media/js/src/forms/add_time_form.js
@@ -1,6 +1,7 @@
 require([
+    'jquery',
     'forms/utils'
-], function(formUtils) {
+], function($, formUtils) {
     $(document).ready(function() {
         $('#add-time-form').submit(function(event) {
             var $form = $(event.target);

--- a/media/js/src/forms/add_tracker_form.js
+++ b/media/js/src/forms/add_tracker_form.js
@@ -1,6 +1,7 @@
 require([
+    'jquery',
     'forms/utils'
-], function(formUtils) {
+], function($, formUtils) {
     $(document).ready(function() {
         $('#add-tracker-form').submit(function(event) {
             var $form = $(event.target);

--- a/media/js/src/forms/project_action_item_modals.js
+++ b/media/js/src/forms/project_action_item_modals.js
@@ -1,0 +1,21 @@
+/**
+ * This adds the Markdown previewer to the optional comment in the
+ * "Mark as In Progress" and "Resolve Item" modals.
+ */
+require([
+    'utils/markdown_preview'
+], function(MarkdownPreview) {
+    $(document).ready(function() {
+        var preview = new MarkdownPreview(
+            $('textarea#dmt-project-item-resolve-comment'),
+            $('.dmt-markdown-project-item-resolve-preview')
+        );
+        preview.startEventHandler();
+
+        preview = new MarkdownPreview(
+            $('textarea#dmt-project-item-inprogress-comment'),
+            $('.dmt-markdown-project-item-inprogress-preview')
+        );
+        preview.startEventHandler();
+    });
+});

--- a/media/js/src/forms/project_action_item_modals.js
+++ b/media/js/src/forms/project_action_item_modals.js
@@ -3,8 +3,9 @@
  * "Mark as In Progress" and "Resolve Item" modals.
  */
 require([
+    'jquery',
     'utils/markdown_preview'
-], function(MarkdownPreview) {
+], function($, MarkdownPreview) {
     $(document).ready(function() {
         var preview = new MarkdownPreview(
             $('textarea#dmt-project-item-resolve-comment'),

--- a/media/js/src/forms/project_add_action_item_form.js
+++ b/media/js/src/forms/project_add_action_item_form.js
@@ -1,9 +1,10 @@
 require([
-    '../libs/bootstrap-datepicker/bootstrap-datepicker.min',
+    'jquery',
+    'bootstrap-datepicker',
 
     'utils/markdown_preview',
     'forms/utils'
-], function(datepicker, MarkdownPreview, formUtils) {
+], function($, datepicker, MarkdownPreview, formUtils) {
     function setupDateSwitcher() {
         var $selectEl = $('#add-action-item-form #action_item-milestone');
 

--- a/media/js/src/forms/project_add_bug_form.js
+++ b/media/js/src/forms/project_add_bug_form.js
@@ -1,9 +1,10 @@
 require([
-    '../libs/bootstrap-datepicker/bootstrap-datepicker.min',
+    'jquery',
+    'bootstrap-datepicker',
 
     'utils/markdown_preview',
     'forms/utils'
-], function(datepicker, MarkdownPreview, formUtils) {
+], function($, datepicker, MarkdownPreview, formUtils) {
     function setupDateSwitcher() {
         var $selectEl = $('#add-bug-form #bug-milestone');
 

--- a/media/js/src/forms/utils.js
+++ b/media/js/src/forms/utils.js
@@ -1,4 +1,8 @@
-define(['underscore'], function(_) {
+define([
+    'jquery',
+    'underscore',
+    'bootstrap-datepicker'
+], function($, _) {
     var FormUtils = function() {};
 
     FormUtils.prototype.refreshTargetDate = function($selectEl, targetDates) {

--- a/media/js/src/main.js
+++ b/media/js/src/main.js
@@ -49,6 +49,7 @@ require([
     'forms/add_tracker_form',
     'forms/project_add_action_item_form',
     'forms/project_add_bug_form',
+    'forms/project_action_item_modals',
     'item'
 ], function($) {
     var csrftoken = $.cookie('csrftoken');


### PR DESCRIPTION
"Resolve item" dialog and "Mark as In Progress" dialog were missing the previewer.

This also includes a fix for the require.js error:
> Error: Load timeout for modules: bootstrap-datepicker http://requirejs.org/docs/errors.html#timeout