### PR TITLE
Display totals for "Outstanding Items" and "Owned Items"

### DIFF
--- a/dmt/templates/main/index.html
+++ b/dmt/templates/main/index.html
@@ -107,11 +107,23 @@
   <ul class="nav nav-tabs project-tabs">
     {% if overdue_milestones %}
       <li class="active"><a href="#overdue-milestones" data-toggle="tab">Overdue Milestones</a></li>
-      <li><a href="#outstanding-items" data-toggle="tab">Outstanding Items</a></li>
+    <li>
+        <a href="#outstanding-items" data-toggle="tab"
+           >Outstanding Items
+            (<strong>{{ pmt_user.items|length }}</strong>)</a>
+    </li>
     {% else %}
-      <li class="active"><a href="#outstanding-items" data-toggle="tab">Outstanding Items</a></li>
+    <li class="active">
+        <a href="#outstanding-items" data-toggle="tab"
+           >Outstanding Items
+            (<strong>{{ pmt_user.items|length }}</strong>)</a>
+    </li>
     {% endif %}
-      <li><a href="#owned-items" data-toggle="tab">Owned Items</a></li>
+    <li>
+        <a href="#owned-items" data-toggle="tab"
+           >Owned Items
+            (<strong>{{ pmt_user.open_owned_items|length }}</strong>)</a>
+    </li>
   </ul>
 
 <div class="tab-content">


### PR DESCRIPTION
This is just an idea, but I thought it would be nice to have the number of open items on the index page:

![2015-01-29-165023_411x261_scrot](https://cloud.githubusercontent.com/assets/59292/5966983/0ca23520-a7d7-11e4-969d-66ffe04bad13.png)

Since I have so many open action items, closing a few of them doesn't really make much of a difference. I think it'd be nice to see this number go down when I close them.