### PR TITLE
Attachment ui more update

### DIFF
--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -686,28 +686,28 @@
 
 {% for attachment in item.attachment_set.all %}
 <div class="row">
-    <div class="col-sm-6">
-        <div class="attachment-thumbnail">
-            {% if attachment.image %}
-            {% if attachment.url %}
-            <a href="{{attachment.url}}"><img src="{{attachment.url}}" /></a>
-            {% else %}
-            <a href="{{attachment.src}}"><img src="{{attachment.src}}" /></a>
-            {% endif %}
-            {% else %}
-            <img src="/media/img/icon-document.png" />
-            {% endif %}
+    <div class="col-sm-2" class="attachment-thumbnail">
+    {% if attachment.image %}
+        {% if attachment.url %}
+        <a href="{{attachment.url}}"><img src="{{attachment.url}}" class="attachment-image" /></a>
+        {% else %}
+        <a href="{{attachment.src}}"><img src="{{attachment.src}}" class="attachment-image" /></a>
+        {% endif %}
+    {% else %}
+        <a href="{{attachment.url}}"><img src="/media/img/icon-document.png" class="attachment-document" /></a>
+    {% endif %}
+    </div><!-- attachment thumbnail -->
+    <div class="col-sm-10">
+        <div class="attachment-title">
+        <h4>{{attachment.title|default:attachment.filename}}</h4>
         </div>
-    </div>
-    <div class="col-sm-6">
+        
+        <div class="attachment-byline text-muted">
+        Uploaded by <a href="{% url 'user_detail' attachment.author.username %}">{{attachment.author.fullname}}</a>
+        on {{attachment.last_mod}}
+        </div>
         <div class="attachment-description">
             {{attachment.description|markdown|emoji_replace}}
-        </div>
-        <div class="attachment-metadata">
-            Uploaded by
-            <a href="{% url 'user_detail' attachment.author.username %}"
-               >{{attachment.author.fullname}}</a>
-            on {{attachment.last_mod}}
         </div>
         <ul class="attachment-action-set clearfix">
             <li class="attachment-action">
@@ -718,12 +718,9 @@
                     <span class="attachment-action-text">Delete</span></a>
             </li>
         </ul>
-    </div>
-</div>
-<hr />
+    </div><!-- attachment details -->
+</div><!-- /.row -->
 {% endfor %}
-
-
 {% endif %}
 
 

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -460,10 +460,26 @@ span.item-action-text {
     background-color: #ebf0f5;
 }
 
-.attachment-thumbnail { width: 120px; }
-.attachment-thumbnail img {
-    max-width: 300px;
-    max-height: 300px;
+.attachment-image {
+    width: 100%;
+    max-width: 250px;
+    text-align: center;
+}
+
+.attachment-document {
+    width: 100%;
+    max-width: 100px;
+}
+
+.attachment-title {
+    margin: 0 0 5px 0;
+    padding: 0;
+}
+
+.attachment-byline {
+    margin: 0 0 10px 0;
+    padding: 0;
+    font-size: 12px;
 }
 
 .attachment-action-set {


### PR DESCRIPTION
![screen shot 2015-02-04 at 11 31 16 am](https://cloud.githubusercontent.com/assets/976843/6044597/4cd97d6c-ac62-11e4-8307-b77fd0e5c9b3.png)

* I restored the link to the document thumbnail (non-image attachments) so it behaves the same way as the image attachments
* Thumbnail for the image attachments is smaller, and its column narrower
* Restored title of attachments