### PR TITLE
Avoid BadHeaderError when calling send_mail() PMT #99266

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -569,7 +569,10 @@ to reply, please visit <https://dmt.ccnmtl.columbia.edu%s>\n"
             u.email for u in self.all_personnel_in_project()
             if u != user]
         subject = "[PMT Forum %s]: %s" % (self.name, node.subject)
+
         statsd.incr('main.email_sent')
+        # Avoid BadHeaderError - The subject can't contain newlines.
+        subject = subject.replace('\n', ' ').replace('\r', '')
         send_mail(subject, body, user.email,
                   addresses, fail_silently=settings.DEBUG)
 
@@ -1126,6 +1129,9 @@ Please do not reply to this message.
             body, self.type, self.get_absolute_url()
         )
         addresses = [u.email for u in self.users_to_email(user)]
+
+        # Avoid BadHeaderError - The subject can't contain newlines.
+        email_subj = email_subj.replace('\n', ' ').replace('\r', '')
         send_mail(email_subj, email_body, user.email,
                   addresses, fail_silently=settings.DEBUG)
         statsd.incr('main.email_sent')
@@ -1360,6 +1366,9 @@ class Node(models.Model):
             "\n\n-- \nthis message sent automatically by the PMT forum.\n"
             "to reply, please visit <https://dmt.ccnmtl.columbia.edu%s>\n" % (
                 self.get_absolute_url()))
+
+        # Avoid BadHeaderError - The subject can't contain newlines.
+        subject = subject.replace('\n', ' ').replace('\r', '')
         send_mail(subject, body, user.email,
                   [self.author.email], fail_silently=settings.DEBUG)
         statsd.incr('main.email_sent')

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -352,6 +352,11 @@ def interval_sum(intervals):
     return total
 
 
+# Avoid BadHeaderError - The subject can't contain newlines.
+def clean_subject(s):
+    return s.replace('\n', ' ').replace('\r', '')
+
+
 class Project(models.Model):
     pid = models.AutoField(primary_key=True)
     name = models.CharField("Project name", max_length=255)
@@ -571,9 +576,7 @@ to reply, please visit <https://dmt.ccnmtl.columbia.edu%s>\n"
         subject = "[PMT Forum %s]: %s" % (self.name, node.subject)
 
         statsd.incr('main.email_sent')
-        # Avoid BadHeaderError - The subject can't contain newlines.
-        subject = subject.replace('\n', ' ').replace('\r', '')
-        send_mail(subject, body, user.email,
+        send_mail(clean_subject(subject), body, user.email,
                   addresses, fail_silently=settings.DEBUG)
 
     def personnel_in_project(self):
@@ -1130,9 +1133,7 @@ Please do not reply to this message.
         )
         addresses = [u.email for u in self.users_to_email(user)]
 
-        # Avoid BadHeaderError - The subject can't contain newlines.
-        email_subj = email_subj.replace('\n', ' ').replace('\r', '')
-        send_mail(email_subj, email_body, user.email,
+        send_mail(clean_subject(email_subj), email_body, user.email,
                   addresses, fail_silently=settings.DEBUG)
         statsd.incr('main.email_sent')
 
@@ -1367,9 +1368,7 @@ class Node(models.Model):
             "to reply, please visit <https://dmt.ccnmtl.columbia.edu%s>\n" % (
                 self.get_absolute_url()))
 
-        # Avoid BadHeaderError - The subject can't contain newlines.
-        subject = subject.replace('\n', ' ').replace('\r', '')
-        send_mail(subject, body, user.email,
+        send_mail(clean_subject(subject), body, user.email,
                   [self.author.email], fail_silently=settings.DEBUG)
         statsd.incr('main.email_sent')
 


### PR DESCRIPTION
This fixes a bug where resolving items in /milestone/3400/ raises a
BadHeaderError seen here:
  https://github.com/django/django/blob/master/django/core/mail/message.py#L88

This can also be triggered by an `/external_add_item/` form if it uses newlines,
e.g. the form here: http://ccnmtl.columbia.edu/remote/204SignIn/ before I worked
around it by changing newlines to dashes.

Example sentry error: https://sentry.ccnmtl.columbia.edu/dmt/dmt/group/493/