### PR TITLE
:racehorse: improve homepage load time

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -133,7 +133,7 @@ class UserProfile(models.Model):
             status__in=['OPEN', 'UNASSIGNED', 'INPROGRESS']
             ).exclude(
             milestone__name='Someday/Maybe').select_related(
-            'milestone', 'milestone__project')
+                'milestone', 'milestone__project', 'owner', 'assigned_to')
 
     def open_owned_items(self):
         """ for the 'owned items' page. """
@@ -141,14 +141,14 @@ class UserProfile(models.Model):
             owner=self,
             status__in=['OPEN', 'UNASSIGNED', 'INPROGRESS', 'RESOLVED']
         ).order_by('-priority', '-target_date').select_related(
-            'milestone', 'milestone__project')
+            'milestone', 'milestone__project', 'owner', 'assigned_to')
 
     def resolved_owned_items(self):
         return Item.objects.filter(
             owner=self,
             status='RESOLVED'
             ).select_related(
-            'milestone', 'milestone__project')
+                'milestone', 'milestone__project', 'owner', 'assigned_to')
 
     def non_verified_owned_items(self):
         """ all items that this user owns that
@@ -307,7 +307,7 @@ class UserProfile(models.Model):
             project__caretaker=self,
             status='OPEN',
             target_date__lt=datetime.now(),
-        ).order_by('target_date')
+        ).order_by('target_date').select_related('project')
 
 
 def create_user_profile(sender, instance, created, **kwargs):


### PR DESCRIPTION
The recent additions of owned items and listing the owner on each
item in the list of outstanding items on the homepage were causing
a lot of extra queries and slowing things down if you have a lot
of items on the page. Added some select_related()s to pull that
info back into the top level queries and avoid the N+1 problems
that had crept in. On my homepage in testing, it reduced it from 250 queries
down to 34.