### PR TITLE
Fix 403 forbidden error - PMT #95796

### DIFF
--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -1108,7 +1108,12 @@ class SignS3View(LoggedInMixin, View):
 
         signature = base64.encodestring(
             hmac.new(AWS_SECRET_KEY, put_request, sha1).digest())
+
         signature = urllib.quote_plus(signature.strip())
+
+        # Encode the plus symbols
+        # https://pmt.ccnmtl.columbia.edu/item/95796/
+        signature = urllib.quote(signature)
 
         url = 'https://s3.amazonaws.com/%s/%s' % (S3_BUCKET, object_name)
         signed_request = '%s?AWSAccessKeyId=%s&Expires=%d&Signature=%s' % (


### PR DESCRIPTION
Fix 403 forbidden error - PMT #95796

The issue seemed to be that the signature was getting decoded
somewhere it shouldn't have been. I'm unclear whether this was django,
the browser, or amazon.

On stackoverflow, someone suggested encoding the signature twice:
  http://stackoverflow.com/a/20712482/173630

That gave me an idea that we need to encode things twice, so my
solution is to encode the signature again with `.quote()` (but
both quote() or quote_plus() will work).

To get an idea of what this actually does:

    s = 'wpPbVzrOCynvHaz VcxCycVShN4='

    s = urllib.quote_plus(s.strip())
    'wpPbVzrOCynvHaz+VcxCycVShN4%3D'

    s = urllib.quote(s)
    'wpPbVzrOCynvHaz%2BVcxCycVShN4%253D'

Now, in Chrome's network tab, the Signature always appears with
plusses, instead of spaces, and Amazon accepts the upload.
