### PR TITLE
Firefox on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ addons:
   postgresql: "9.3"
 python:
   - "2.7"
+before_install:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 install:
   - ./bootstrap.py
 before_script:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -51,7 +51,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS', 'Firefox'],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "karma": "~0.12.24",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.4",
+    "karma-firefox-launcher": "~0.1.4",
     "karma-qunit": "~0.1.4",
     "karma-requirejs": "~0.2.2",
     "karma-sinon": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Project management tool",
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start"
+    "test": "./node_modules/karma/bin/karma start --browsers Firefox --single-run"
   },
   "devDependencies": {
     "casperjs": "~1.1.0-beta3",


### PR DESCRIPTION
Not sure we actually want to merge this. Mostly putting it up to start discussion.

Looks TravisCI actually makes it pretty straightforward to run Firefox so we could do full browser testing. Since DMT already had Karma and PhantomJS set up, I used it as a test to get it to just run the tests against Firefox instead of PhantomJS and it seems to work.

This is encouraging as far as making it likely that I'm willing to put more time and effort into getting a Selenium testing setup back (but almost certainly dropping Lettuce in favor of Behave for any BDD stuff).