### PR TITLE
set up a basic oauth2 endpoint

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -142,6 +142,8 @@ INSTALLED_APPS = [
     'dmt.api',
     'bdd_tests',
     'django_behave',
+    'provider',
+    'provider.oauth2',
 ]
 
 if 'jenkins' in sys.argv:

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -54,6 +54,7 @@ urlpatterns = patterns(
     url(r'^add_trackers/$', AddTrackersView.as_view(), name='add_trackers'),
     (r'^api/1.0/', include('dmt.api.urls')),
     (r'^drf/', include('dmt.api.urls')),
+    url(r'^oauth2/', include('provider.oauth2.urls', namespace='oauth2')),
     (r'^search/$', SearchView.as_view()),
     (r'^client/$', ClientListView.as_view()),
     url(r'^client/(?P<pk>\d+)/$', ClientDetailView.as_view(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ boto==2.34.0
 unicodecsv==0.9.4
 XlsxWriter==0.6.1
 splinter==0.7.0
+shortuuid==0.4.2
 
 djangowind==0.13.2
 django-staticmedia==0.2.2
@@ -87,3 +88,4 @@ django-casper==0.0.2c
 django-bootstrap3==5.1.1
 django-emoji==2.0.0
 django-behave==0.1.3
+django-oauth2-provider==0.2.6.1


### PR DESCRIPTION
django-rest-framework supports oauth2 directly, so with this we can issue credentials
that other apps can then use to directly access the PMTs API.

Ultimately, this is probably how we want to be doing the external add item stuff
in most cases. I'm also interested in being able to provide alternate clients
for interacting with the PMT. Eg, I really want to make a little commandline tool
that will let me do some common tasks without having to pull up a browser.