### PR TITLE
Use postgresql when running tests locally

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -20,7 +20,7 @@ DATABASES = {
     }
 }
 
-if 'test' in sys.argv or 'jenkins' in sys.argv:
+if 'jenkins' in sys.argv:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
This is just an idea. We have a bunch of tests in dmt that
require postgresql, because of how it's written. I think that
they should run by default when running `make test`, since any
developer machine would have postgresql installed, since it's
required to run `make runserver`.

This changes the settings to use postgresql on `make test`, but
use sqlite on `make jenkins`.