### PR TITLE
Fix requirejs error on npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,17 @@
   },
   "devDependencies": {
     "casperjs": "~1.1.0-beta3",
-    "karma": "~0.12.24",
+    "karma": "~0.12.31",
+    "karma-junit-reporter": "~0.2.2",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.4",
+    "qunitjs": "~1.17.1",
     "karma-qunit": "~0.1.4",
+    "requirejs": "~2.1.17",
     "karma-requirejs": "~0.2.2",
-    "karma-sinon": "~1.0.3",
-    "phantomjs": "~1.9.12",
-    "sinon": "~1.11.1",
+    "karma-sinon": "~1.0.4",
+    "phantomjs": "~1.9.16",
+    "sinon": "~1.14.1",
     "sinon-qunit": "~2.0.0"
   },
   "repository": {


### PR DESCRIPTION
The issue is that qunit v1.18.0 (released today) breaks when
loaded with requirejs. I pinned the version of qunit we're using
at 1.17.x, which fixes the problem for now.

https://github.com/jquery/qunit/issues/807