### PR TITLE
Use commonmark in python - PMT #98979

### DIFF
--- a/dmt/main/templatetags/dmttags.py
+++ b/dmt/main/templatetags/dmttags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.safestring import mark_safe
 import dmt.main.utils as utils
 
 register = template.Library()
@@ -25,3 +26,8 @@ def format_mdy(dt):
 @register.filter
 def interval_to_hours(duration):
     return utils.interval_to_hours(duration)
+
+
+@register.filter(is_safe=True)
+def markdown(value):
+    return mark_safe(utils.commonmark_render(value))

--- a/dmt/main/utils.py
+++ b/dmt/main/utils.py
@@ -1,6 +1,19 @@
 import ntpath
 import re
+from django.utils.encoding import smart_str
+import CommonMark
 from simpleduration import Duration, InvalidDuration
+
+
+def commonmark_render(text):
+    """Render a string of commonmark text to html.
+
+    :rtype: str
+    """
+    parser = CommonMark.DocParser()
+    renderer = CommonMark.HTMLRenderer()
+    ast = parser.parse(text)
+    return smart_str(renderer.render(ast))
 
 
 def new_duration(timestr):

--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -135,7 +135,6 @@ INSTALLED_APPS = [
     'taggit',
     'taggit_templatetags',
     'djcelery',
-    'django_markwhat',
     'bootstrap3',
     'emoji',
     'dmt.main',

--- a/dmt/templates/flatpages/default.html
+++ b/dmt/templates/flatpages/default.html
@@ -8,7 +8,7 @@
 {% endcomment %}
 
 
-{% load markup %}
+{% load dmttags %}
 {% load thumbnail %}
 
 {% block title %}{{ flatpage.title }}{% endblock %}

--- a/dmt/templates/main/dashboard.html
+++ b/dmt/templates/main/dashboard.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load emoji_tags %}
 
 {% block content %}

--- a/dmt/templates/main/group_detail.html
+++ b/dmt/templates/main/group_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 
 {% block title %}Group: {{object.readable_group_name}}{% endblock %}
 

--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load waffle_tags %}
 {% load emoji_tags %}
 

--- a/dmt/templates/main/milestone_detail.html
+++ b/dmt/templates/main/milestone_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load emoji_tags %}
 
 {% block title %}Milestone&ndash;{{object.name}}{% endblock %}

--- a/dmt/templates/main/node_detail.html
+++ b/dmt/templates/main/node_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load emoji_tags %}
 
 

--- a/dmt/templates/main/node_list.html
+++ b/dmt/templates/main/node_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load emoji_tags %}
 
 {% block title %}Forum Posts{% endblock %}

--- a/dmt/templates/main/project_detail.html
+++ b/dmt/templates/main/project_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load waffle_tags %}
 {% load emoji_tags %}
 

--- a/dmt/templates/main/project_timeline.html
+++ b/dmt/templates/main/project_timeline.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load waffle_tags %}
 {% load emoji_tags %}
 

--- a/dmt/templates/main/statusupdate_list.html
+++ b/dmt/templates/main/statusupdate_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load emoji_tags %}
 
 {% block title %}Status Updates of Projects{% endblock %}

--- a/dmt/templates/main/user_detail.html
+++ b/dmt/templates/main/user_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load waffle_tags %}
 {% load emoji_tags %}
 

--- a/dmt/templates/main/user_timeline.html
+++ b/dmt/templates/main/user_timeline.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 {% load waffle_tags %}
 {% load emoji_tags %}
 

--- a/dmt/templates/report/passed_milestones.html
+++ b/dmt/templates/report/passed_milestones.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 
 {% block content %}
 <ul class="breadcrumb">

--- a/dmt/templates/report/resolved.html
+++ b/dmt/templates/report/resolved.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markup %}
+{% load dmttags %}
 
 {% block css %}
 <link rel="stylesheet" href="{{STATIC_URL}}css/tablecloth.css">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.7.7
-Markdown==2.6.1
+CommonMark==0.5.4
 uuid==1.30
 psycopg2==2.5.4
 nose==1.3.4
@@ -83,7 +83,6 @@ django-taggit==0.12.1a
 django-templatetag-sugar==1.0
 django-taggit-templatetags==0.4.6dev
 django-celery==3.1.16
-django-markwhat==2014.9.20
 django-casper==0.0.2c
 django-bootstrap3==5.2.0
 django-emoji==2.0.0


### PR DESCRIPTION
remarkable.js supports the CommonMark spec, so now we're using the same
version of markdown on the back-end and the front-end.