### PR TITLE
Use new search filter in project autocomplete - PMT #99496

### DIFF
--- a/dmt/api/filters.py
+++ b/dmt/api/filters.py
@@ -1,0 +1,37 @@
+from rest_framework import filters
+
+
+class ProjectSearchFilter(filters.SearchFilter):
+    def get_search_terms(self, request):
+        """
+        Search terms are set by a ?search=... query parameter,
+        and may be comma delimited.
+
+        Unlike DRF's upstream search tokenizer, this one allows to
+        search for tokens that contain spaces.
+        """
+        params = request.query_params.get(self.search_param, '')
+        params = params.replace(',', ' ')
+        return [params] + params.split()
+
+    @staticmethod
+    def startswith_term(name, term):
+        """Sort by whether or not name starts with term"""
+        if name.lower().startswith(term.lower()):
+            return -1
+        else:
+            return 1
+
+    def filter_queryset(self, request, queryset, view):
+        queryset = super(ProjectSearchFilter, self).filter_queryset(
+            request, queryset, view)
+
+        term = request.query_params.get(self.search_param, '')
+        if term:
+            # Put startswith matches at the beginning, and then sort
+            # alphabetically by name.
+            queryset = sorted(
+                queryset,
+                key=lambda p: (self.startswith_term(p.name, term), p.name))
+
+        return queryset

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -5,7 +5,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt
 
-from rest_framework import filters, generics, viewsets
+from rest_framework import generics, viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from simpleduration import Duration, InvalidDuration
@@ -18,6 +18,7 @@ from dmt.main.models import (
 from dmt.main.utils import new_duration
 
 from dmt.api.auth import SafeOriginAuthentication, SafeOriginPermission
+from dmt.api.filters import ProjectSearchFilter
 from dmt.api.serializers import (
     ClientSerializer, ItemSerializer, MilestoneSerializer, NotifySerializer,
     ProjectSerializer, UserSerializer,
@@ -311,8 +312,8 @@ class AddTrackerView(View):
 class ProjectViewSet(viewsets.ModelViewSet):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
-    filter_backends = (filters.SearchFilter,)
-    search_fields = ('name',)
+    filter_backends = (ProjectSearchFilter,)
+    search_fields = ('^name', 'name',)
     paginate_by = 20
 
 

--- a/media/js/src/main.js
+++ b/media/js/src/main.js
@@ -34,8 +34,8 @@ require.config({
 require([
     // libs
     'jquery',
-    '../libs/jquery.cookie.min',
     'underscore',
+    '../libs/jquery.cookie.min',
     'backbone',
     'bootstrap-datepicker',
     '../libs/remarkable/remarkable',
@@ -51,7 +51,7 @@ require([
     'forms/project_add_bug_form',
     'forms/project_action_item_modals',
     'item'
-], function($) {
+], function($, _) {
     var csrftoken = $.cookie('csrftoken');
 
     // The following is from
@@ -91,21 +91,10 @@ require([
         datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         limit: 10,
-        prefetch: {
-            url: '/drf/projects/',
-            filter: function(projects) {
-                return $.map(projects.results, function(data) {
-                    return {
-                        name: data.name,
-                        pid: data.pid
-                    };
-                });
-            }
-        },
         remote: {
             url: '/drf/projects/?search=%QUERY',
             filter: function(projects) {
-                return $.map(projects.results, function(data) {
+                return _.map(projects.results, function(data) {
                     return {
                         name: data.name,
                         pid: data.pid
@@ -131,6 +120,7 @@ require([
             displayKey: 'name',
             source: projects.ttAdapter()
         });
+
         $('#project-input').on('typeahead:selected', function(object, datum) {
             $('#tracker-pid-input').val(datum.pid);
         });


### PR DESCRIPTION
The most important change here is that we're now filtering
the projects with a `startswith` search instead of `contains`.
This gives better results, closer to what I think people expect.

I had to override a method in DRF's SearchFilter in order to
allow us to search on terms with spaces, (e.g. try searching
for "project m" to find the "Project Management Tool" project).
I might make a pull request upstream if I find no existing way to
configure this.