### PR TITLE
Set required env vars for 'make test'

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -33,6 +33,8 @@ if 'jenkins' in sys.argv:
             'ATOMIC_REQUESTS': True,
         }
     }
+
+if 'test' in sys.argv or 'jenkins' in sys.argv:
     CELERY_ALWAYS_EAGER = True
 
     WHITELIST_ORIGIN_IPS = (


### PR DESCRIPTION
My change for running postgresql locally broke the other tests that require
WHITELIST_ORIGIN_IPS to be set.