### PR TITLE
Fix js loading time bug - PMT #99105

### DIFF
--- a/media/js/libs/require/domReady.js
+++ b/media/js/libs/require/domReady.js
@@ -1,0 +1,131 @@
+/**
+ * @license RequireJS domReady 2.0.1 Copyright (c) 2010-2012, The Dojo Foundation All Rights Reserved.
+ * Available via the MIT or new BSD license.
+ * see: http://github.com/requirejs/domReady for details
+ */
+/*jslint */
+/*global require: false, define: false, requirejs: false,
+  window: false, clearInterval: false, document: false,
+  self: false, setInterval: false */
+
+
+define(function () {
+    'use strict';
+
+    var isTop, testDiv, scrollIntervalId,
+        isBrowser = typeof window !== "undefined" && window.document,
+        isPageLoaded = !isBrowser,
+        doc = isBrowser ? document : null,
+        readyCalls = [];
+
+    function runCallbacks(callbacks) {
+        var i;
+        for (i = 0; i < callbacks.length; i += 1) {
+            callbacks[i](doc);
+        }
+    }
+
+    function callReady() {
+        var callbacks = readyCalls;
+
+        if (isPageLoaded) {
+            //Call the DOM ready callbacks
+            if (callbacks.length) {
+                readyCalls = [];
+                runCallbacks(callbacks);
+            }
+        }
+    }
+
+    /**
+     * Sets the page as loaded.
+     */
+    function pageLoaded() {
+        if (!isPageLoaded) {
+            isPageLoaded = true;
+            if (scrollIntervalId) {
+                clearInterval(scrollIntervalId);
+            }
+
+            callReady();
+        }
+    }
+
+    if (isBrowser) {
+        if (document.addEventListener) {
+            //Standards. Hooray! Assumption here that if standards based,
+            //it knows about DOMContentLoaded.
+            document.addEventListener("DOMContentLoaded", pageLoaded, false);
+            window.addEventListener("load", pageLoaded, false);
+        } else if (window.attachEvent) {
+            window.attachEvent("onload", pageLoaded);
+
+            testDiv = document.createElement('div');
+            try {
+                isTop = window.frameElement === null;
+            } catch (e) {}
+
+            //DOMContentLoaded approximation that uses a doScroll, as found by
+            //Diego Perini: http://javascript.nwbox.com/IEContentLoaded/,
+            //but modified by other contributors, including jdalton
+            if (testDiv.doScroll && isTop && window.external) {
+                scrollIntervalId = setInterval(function () {
+                    try {
+                        testDiv.doScroll();
+                        pageLoaded();
+                    } catch (e) {}
+                }, 30);
+            }
+        }
+
+        //Check if document already complete, and if so, just trigger page load
+        //listeners. Latest webkit browsers also use "interactive", and
+        //will fire the onDOMContentLoaded before "interactive" but not after
+        //entering "interactive" or "complete". More details:
+        //http://dev.w3.org/html5/spec/the-end.html#the-end
+        //http://stackoverflow.com/questions/3665561/document-readystate-of-interactive-vs-ondomcontentloaded
+        //Hmm, this is more complicated on further use, see "firing too early"
+        //bug: https://github.com/requirejs/domReady/issues/1
+        //so removing the || document.readyState === "interactive" test.
+        //There is still a window.onload binding that should get fired if
+        //DOMContentLoaded is missed.
+        if (document.readyState === "interactive" ||
+            document.readyState === "complete"
+           ) {
+            pageLoaded();
+        }
+    }
+
+    /** START OF PUBLIC API **/
+
+    /**
+     * Registers a callback for DOM ready. If DOM is already ready, the
+     * callback is called immediately.
+     * @param {Function} callback
+     */
+    function domReady(callback) {
+        if (isPageLoaded) {
+            callback(doc);
+        } else {
+            readyCalls.push(callback);
+        }
+        return domReady;
+    }
+
+    domReady.version = '2.0.1';
+
+    /**
+     * Loader Plugin API method
+     */
+    domReady.load = function (name, req, onLoad, config) {
+        if (config.isBuild) {
+            onLoad(null);
+        } else {
+            domReady(onLoad);
+        }
+    };
+
+    /** END OF PUBLIC API **/
+
+    return domReady;
+});

--- a/media/js/src/forms/add_time_form.js
+++ b/media/js/src/forms/add_time_form.js
@@ -1,8 +1,9 @@
 require([
+    'domReady',
     'jquery',
     'forms/utils'
-], function($, formUtils) {
-    $(document).ready(function() {
+], function(domReady, $, formUtils) {
+    domReady(function() {
         $('#add-time-form').submit(function(event) {
             var $form = $(event.target);
             var time = $form.find('#tracker-time-input').val();

--- a/media/js/src/forms/add_tracker_form.js
+++ b/media/js/src/forms/add_tracker_form.js
@@ -1,8 +1,9 @@
 require([
+    'domReady',
     'jquery',
     'forms/utils'
-], function($, formUtils) {
-    $(document).ready(function() {
+], function(domReady, $, formUtils) {
+    domReady(function() {
         $('#add-tracker-form').submit(function(event) {
             var $form = $(event.target);
             var pid = $form.find('#tracker-pid-input').val();

--- a/media/js/src/forms/project_action_item_modals.js
+++ b/media/js/src/forms/project_action_item_modals.js
@@ -3,10 +3,11 @@
  * "Mark as In Progress" and "Resolve Item" modals.
  */
 require([
+    'domReady',
     'jquery',
     'utils/markdown_preview'
-], function($, MarkdownPreview) {
-    $(document).ready(function() {
+], function(domReady, $, MarkdownPreview) {
+    domReady(function() {
         var preview = new MarkdownPreview(
             $('textarea#dmt-project-item-resolve-comment'),
             $('.dmt-markdown-project-item-resolve-preview')

--- a/media/js/src/forms/project_add_action_item_form.js
+++ b/media/js/src/forms/project_add_action_item_form.js
@@ -1,10 +1,11 @@
 require([
+    'domReady',
     'jquery',
     'bootstrap-datepicker',
 
     'utils/markdown_preview',
     'forms/utils'
-], function($, datepicker, MarkdownPreview, formUtils) {
+], function(domReady, $, datepicker, MarkdownPreview, formUtils) {
     function setupDateSwitcher() {
         var $selectEl = $('#add-action-item-form #action_item-milestone');
 
@@ -23,7 +24,7 @@ require([
         });
     }
 
-    $(document).ready(function() {
+    domReady(function() {
         if (!$('#add-action-item-form')) {
             return;
         }

--- a/media/js/src/forms/project_add_bug_form.js
+++ b/media/js/src/forms/project_add_bug_form.js
@@ -1,10 +1,11 @@
 require([
+    'domReady',
     'jquery',
     'bootstrap-datepicker',
 
     'utils/markdown_preview',
     'forms/utils'
-], function($, datepicker, MarkdownPreview, formUtils) {
+], function(domReady, $, datepicker, MarkdownPreview, formUtils) {
     function setupDateSwitcher() {
         var $selectEl = $('#add-bug-form #bug-milestone');
 
@@ -23,7 +24,7 @@ require([
         });
     }
 
-    $(document).ready(function() {
+    domReady(function() {
         if (!$('#add-bug-form')) {
             return;
         }

--- a/media/js/src/main.js
+++ b/media/js/src/main.js
@@ -7,6 +7,7 @@ require.config({
 
         // Require.js plugins
         text: '../libs/require/text',
+        domReady: '../libs/require/domReady',
 
         'bootstrap-datepicker':
             '../libs/bootstrap-datepicker/bootstrap-datepicker.min',


### PR DESCRIPTION
Apparently `jQuery(document).ready()` has issues with require.js,
and require.js's solution is to use their `domReady` plugin:
  http://requirejs.org/docs/api.html#pageload

Even with this plugin, the ready event wasn't firing until all the
nanny-render images were done. I've included a change to the plugin
that waits until document.readyState is `interactive`, as well as
`complete`. Someone has already proposed a similar change here:
  https://github.com/requirejs/domReady/pull/12