### PR TITLE
Fix bug where commonmark_render(None) would throw an exception

### DIFF
--- a/dmt/main/tests/test_utils.py
+++ b/dmt/main/tests/test_utils.py
@@ -1,6 +1,23 @@
+import re
 import unittest
 from datetime import timedelta
 import dmt.main.utils as utils
+
+
+class CommonMarkRenderTests(unittest.TestCase):
+    def test_commonmark_render(self):
+        text = 'Paragraph 1\n\n## An h2'
+        out = utils.commonmark_render(text)
+        pattern = re.compile(r'<p>Paragraph 1\s*</p>\s*<h2>\s*An h2</h2>')
+        self.assertTrue(pattern.match(out))
+
+    def test_commonmark_render_empty(self):
+        out = utils.commonmark_render('')
+        self.assertEqual(out, '')
+
+    def test_commonmark_render_none(self):
+        out = utils.commonmark_render(None)
+        self.assertEqual(out, '<p>None</p>\n')
 
 
 class IntervalToHoursTests(unittest.TestCase):

--- a/dmt/main/utils.py
+++ b/dmt/main/utils.py
@@ -1,6 +1,6 @@
 import ntpath
 import re
-from django.utils.encoding import smart_str
+from django.utils.encoding import force_text, smart_str
 import CommonMark
 from simpleduration import Duration, InvalidDuration
 
@@ -12,7 +12,7 @@ def commonmark_render(text):
     """
     parser = CommonMark.DocParser()
     renderer = CommonMark.HTMLRenderer()
-    ast = parser.parse(text)
+    ast = parser.parse(force_text(text))
     return smart_str(renderer.render(ast))
 
 


### PR DESCRIPTION
The fix for the templatetag is here:
  https://github.com/Alir3z4/django-markwhat/pull/19

Eventually all this functionality will move to django-markwhat.