### PR TITLE
Display 'Primary Group' separately on user detail page

### DIFF
--- a/dmt/templates/main/user_detail.html
+++ b/dmt/templates/main/user_detail.html
@@ -73,19 +73,23 @@
 <dl class="dl-horizontal clearfix">
 {% with object.user_groups as groups %}
 {% if groups %}
-<dt>Groups:</dt><dd>
-{% for g in groups %}
-  <a href="{% url 'group_detail' g.username %}">
-  {{g.group_fullname}}</a>{% if not forloop.last %}, {% endif %}
-{% endfor %}
-{% if object.primary_group %}
-(Primary: <a href="{% url 'group_detail' object.primary_group.username %}"
-   >{{object.primary_group.group_fullname}}</a>)
-{% endif %}
-
+<dt>Groups:</dt>
+<dd>
+    {% for g in groups %}
+    <a href="{% url 'group_detail' g.username %}">
+        {{g.group_fullname}}</a>{% if not forloop.last %}, {% endif %}
+    {% endfor %}
 </dd>
 {% endif %}
 {% endwith %}
+
+{% if object.primary_group %}
+<dt>Primary Group:</dt>
+<dd>
+    <a href="{% url 'group_detail' object.primary_group.username %}"
+       >{{object.primary_group.group_fullname}}</a>
+</dd>
+{% endif %}
 </dl>
 
 


### PR DESCRIPTION
Users can have a primary group even if their 'user_groups' attribute
is empty. This change displays their primary group separately from the
rest of their groups.

![2015-04-15-124004_262x62_scrot](https://cloud.githubusercontent.com/assets/59292/7164236/fa0dbc00-e36c-11e4-8ce3-97f0bb2c78e3.png)
