### PR TITLE
Use default django test runner instead of django-nose.

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -44,12 +44,7 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
         '.columbia.edu',
     )
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--with-coverage',
-    '--cover-package=dmt',
-]
+TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 JENKINS_TASKS = (
     'django_jenkins.tasks.run_pep8',
@@ -124,7 +119,6 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'compressor',
     'django_markwhat',
-    'django_nose',
     'django_statsd',
     'bootstrapform',
     'debug_toolbar',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ CommonMark==0.5.4
 django-markwhat==1.3
 uuid==1.30
 psycopg2==2.5.4
-nose==1.3.4
 versiontools==1.9.1
 statsd==3.0.1
 pep8==1.5.7
@@ -63,7 +62,6 @@ shortuuid==0.4.2
 djangowind==0.13.2
 django-staticmedia==0.2.2
 django-annoying==0.8.0
-django-nose==1.3
 django-appconf==0.6
 django_compressor==1.4
 django-statsd-mozilla==0.3.14


### PR DESCRIPTION
Django 1.6 introduced the [DiscoverRunner](https://docs.djangoproject.com/en/1.8/releases/1.6/#discovery-of-tests-in-any-test-module). django-jenkins has an
issue running with django-nose with Django 1.8: https://github.com/kmmbvnr/django-jenkins/issues/282
It seems like we don't need to use nose at all.