### PR TITLE
fix __init__() got an unexpected keyword argument 'template_name' error

### DIFF
--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -151,6 +151,12 @@ class TestProjectViews(LoggedInTestMixin, TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertContains(r, self.p.name)
 
+    def test_project_board(self):
+        Flag.objects.create(name='project_board', everyone=True)
+        r = self.c.get(self.p.get_absolute_url() + "board/")
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'id="milestones"')
+
     def test_project_report_page(self):
         r = self.c.get(self.p.get_absolute_url() + '#reports')
         self.assertEqual(r.status_code, 200)

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -555,6 +555,7 @@ class ProjectDetailView(LoggedInMixin, RangeOffsetMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         ctx = super(ProjectDetailView, self).get_context_data(**kwargs)
+        self.calc_interval()
         unverified_items = Item.objects.filter(
             milestone__project=self.object).filter(
                 ~Q(status='VERIFIED')

--- a/dmt/report/mixins.py
+++ b/dmt/report/mixins.py
@@ -55,9 +55,6 @@ class RangeOffsetMixin(object):
     range_days = 31
     offset_days = 0
 
-    def __init__(self):
-        self.calc_interval()
-
     def calc_interval(self):
         self.interval_start = date.today() - timedelta(
             days=(self.range_days + self.offset_days))

--- a/dmt/report/tests/test_mixins.py
+++ b/dmt/report/tests/test_mixins.py
@@ -30,6 +30,6 @@ class RangeOffsetMixinTests(TestCase):
         self.mixin = RangeOffsetMixin()
 
     def test_calc_interval(self):
-        # calc_interval() should have been called on init
+        self.mixin.calc_interval()
         self.assertEqual(self.mixin.interval_start,
                          date.today() - timedelta(days=31))

--- a/dmt/report/views.py
+++ b/dmt/report/views.py
@@ -45,7 +45,7 @@ class ActiveProjectsView(LoggedInMixin, RangeOffsetMixin, TemplateView):
     def get_context_data(self, *args, **kwargs):
         context = super(ActiveProjectsView, self).get_context_data(
             *args, **kwargs)
-
+        self.calc_interval()
         calc = ActiveProjectsCalculator()
         data = calc.calc(context.get('interval_start'),
                          context.get('interval_end'))
@@ -56,6 +56,7 @@ class ActiveProjectsView(LoggedInMixin, RangeOffsetMixin, TemplateView):
 class ActiveProjectsExportView(LoggedInMixin, RangeOffsetMixin, View):
     def get(self, request, *args, **kwargs):
         calc = ActiveProjectsCalculator()
+        self.calc_interval()
         data = calc.calc(self.interval_start, self.interval_end)
 
         # Find dates for displaying to the user
@@ -130,6 +131,7 @@ class StaffReportView(LoggedInMixin, RangeOffsetMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(StaffReportView, self).get_context_data(**kwargs)
+        self.calc_interval()
         calc = StaffReportCalculator(['designers', 'programmers', 'video',
                                       'educationaltechnologists',
                                       'management'])
@@ -143,7 +145,7 @@ class StaffReportView(LoggedInMixin, RangeOffsetMixin, TemplateView):
 class StaffReportExportView(LoggedInMixin, RangeOffsetMixin, View):
     def get(self, request, *args, **kwargs):
         self.get_params()
-
+        self.calc_interval()
         calc = StaffReportCalculator(['designers', 'programmers', 'video',
                                       'educationaltechnologists',
                                       'management'])


### PR DESCRIPTION
See: https://sentry.ccnmtl.columbia.edu/sentry-internal/dmt/group/663/

The problem is that the `RangeOffsetMixin` has an `__init__()`, which overrides the
`__init__()` of the generic Django CBVs that lets you specify additional
parameters when you instantiate it in `urls.py`. That's what we do for
the project board view, since it uses the same data as the regular
project detail view, we just re-use that view and specify a different
`template_name` in `urls.py`.

Removed the `__init__()` from `RangeOffsetMixin` and just explicitly call
`calc_interval()` instead.'