### PR TITLE
django-markwhat 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.7.7
 CommonMark==0.5.4
-django-markwhat==1.3
+django-markwhat==1.4
 uuid==1.30
 psycopg2==2.5.4
 versiontools==1.9.1


### PR DESCRIPTION
This fixes an exception that occurs on the item detail
page when the item has no description, e.g. PMT #92734

Fixes sentry error:
https://sentry.ccnmtl.columbia.edu/sentry-internal/dmt/group/638/