### PR TITLE
Add dates and reported hours to project report - PMT #99285

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -717,9 +717,9 @@ ORDER BY hours_logged DESC;
             actualtime__completed__gt=start,
             actualtime__completed__lt=end
         ).distinct().annotate(
-            Max('actualtime__completed'),
-            Sum('actualtime__actual_time')
-        ).order_by('-actualtime__actual_time__sum')
+            last_worked_on=Max('actualtime__completed'),
+            hours_logged=Sum('actualtime__actual_time'),
+        ).order_by('-hours_logged')
 
         return active_users
 

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -566,6 +566,9 @@ class ProjectDetailView(LoggedInMixin, RangeOffsetMixin, DetailView):
             if m in m_set]
         ctx['users_active_in_range'] = ctx['object'].users_active_between(
             self.interval_start, self.interval_end)
+        ctx['total_hours'] = round(
+            sum([u.hours_logged.total_seconds()
+                 for u in ctx['users_active_in_range']]) / 3600, 2)
         return ctx
 
 

--- a/dmt/templates/main/project_detail_report.html
+++ b/dmt/templates/main/project_detail_report.html
@@ -1,6 +1,15 @@
 {% load dmttags %}
 
+<h4>{{interval_start|format_mdy}} &ndash; {{interval_end|format_mdy}}</h4>
 {% include 'report/range_offset_form.html' %}
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="control-group">
+            Total hours reported: <strong>{{total_hours}}</strong>
+        </div>
+    </div>
+</div>
 
 <table id="project-report"
        class="table table-bordered table-striped tablesorter">
@@ -18,8 +27,8 @@
                 <a href="{% url 'user_detail' u.username %}"
                    >{{ u.userprofile.fullname }}</a>
             </td>
-            <td>{{ u.actualtime__actual_time__sum|interval_to_hours }}</td>
-            <td>{{ u.actualtime__completed__max }}</td>
+            <td>{{ u.hours_logged|interval_to_hours }}</td>
+            <td>{{ u.last_worked_on }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/dmt/templates/report/active_projects.html
+++ b/dmt/templates/report/active_projects.html
@@ -11,12 +11,8 @@
     <li class="active">Active Projects</li>
 </ul>
 
-<h2>
-    Most Active Projects
-</h2>
-<h4>
-    {{interval_start|format_mdy}} &ndash; {{interval_end|format_mdy}}
-</h4>
+<h2>Most Active Projects</h2>
+<h4>{{interval_start|format_mdy}} &ndash; {{interval_end|format_mdy}}</h4>
 
 {% include 'report/range_offset_form.html' %}
 


### PR DESCRIPTION
There's a small, related bug with the project detail page I haven't been able to fix yet:
When you navigate straight to one of these pages with the hash in it, like `#reports`,
the browser interprets that as an anchor tag, and scrolls you down to where
`<div id="reports">` appears.

I haven't come up with a work-around yet, and bootstrap
doesn't officially support the behavior of changing the URL when you click a tab.
But I need that behavior for the range/offset form on the project report to behave
correctly.