### PR TITLE
remove users graph from stats page

### DIFF
--- a/dmt/templates/stats.html
+++ b/dmt/templates/stats.html
@@ -21,8 +21,6 @@
 <img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976726.925&target=keepLastValue(ccnmtl.app.timers.dmt.celery.item_stats_report.mean)&target=keepLastValue(ccnmtl.app.timers.dmt.celery.estimates_report.mean)&target=keepLastValue(ccnmtl.app.timers.dmt.celery.hours_logged_report.mean)&hideGrid=true&hideLegend=true&from=-24hours"/>
 <h2>Errors</h2>
 <img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.counters.dmt.response.404&target=ccnmtl.app.counters.dmt.response.500&graphOnly=false&hideGrid=true">
-<h2>Users</h2>
-<img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.gauges.dmt.users.active&graphOnly=false&hideGrid=true">
 </div>
 
 
@@ -39,8 +37,6 @@
 <h2>Errors</h2>
 <img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.counters.dmt.response.404&target=ccnmtl.app.counters.dmt.response.500&graphOnly=false&hideGrid=true&from=-7days">
 
-<h2>Users</h2>
-<img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.gauges.dmt.users.active&graphOnly=false&hideGrid=true&from=-7days">
 </div>
 
 <div id="month" class="tab-pane">
@@ -53,8 +49,6 @@
 <img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976726.925&target=keepLastValue(ccnmtl.app.timers.dmt.celery.item_stats_report.mean)&target=keepLastValue(ccnmtl.app.timers.dmt.celery.estimates_report.mean)&target=keepLastValue(ccnmtl.app.timers.dmt.celery.hours_logged_report.mean)&hideGrid=true&hideLegend=true&from=-1months"/>
 <h2>Errors</h2>
 <img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.counters.dmt.response.404&target=ccnmtl.app.counters.dmt.response.500&graphOnly=false&hideGrid=true&from=-1months">
-<h2>Users</h2>
-<img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.gauges.dmt.users.active&graphOnly=false&hideGrid=true&from=-1months">
 </div>
 
 
@@ -67,8 +61,6 @@
 <img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976726.925&target=keepLastValue(ccnmtl.app.timers.dmt.celery.item_stats_report.mean)&target=keepLastValue(ccnmtl.app.timers.dmt.celery.estimates_report.mean)&target=keepLastValue(ccnmtl.app.timers.dmt.celery.hours_logged_report.mean)&hideGrid=true&hideLegend=true&from=-1years"/>
 <h2>Errors</h2>
 <img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.counters.dmt.response.404&target=ccnmtl.app.counters.dmt.response.500&graphOnly=false&hideGrid=true&from=-1years">
-<h2>Users</h2>
-<img width="900" height="200" src="{{GRAPHITE_BASE}}?width=900&height=200&_salt=1337976132.743&target=ccnmtl.app.gauges.dmt.users.active&graphOnly=false&hideGrid=true&from=-1years">
 </div>
 </div>
 


### PR DESCRIPTION
we no longer track the number of users (that was only interesting when
we still had unclaimed accounts)