### PR TITLE
remove per-milestone hours/estimates graphs

### DIFF
--- a/dmt/templates/main/dashboard.html
+++ b/dmt/templates/main/dashboard.html
@@ -46,8 +46,6 @@
 	({{milestone.num_open_items}} items)</td>
 	<td><a href="{{milestone.project.get_absolute_url}}">{{milestone.project.name|truncatechars:40}}</a></td>
 	<td><a href="{{milestone.get_absolute_url}}">{{milestone.name|truncatechars:40|emoji_replace}}</a></td>
-	<td><img src="{{GRAPHITE_BASE}}?target=ccnmtl.app.gauges.dmt.milestones.{{milestone.mid}}.hours_logged&target=ccnmtl.app.gauges.dmt.milestones.{{milestone.mid}}.hours_estimated&_salt=1369503684.466&height=10&colorList=%2366cc66%2C%23cc6666&hideLegend=true&hideAxes=true&yMin=0&width=50&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=stacked&from=-8months"
-		 width="50" height="10" /></td>
 </tr>
 {% endfor %}
 </table>

--- a/dmt/templates/main/project_detail.html
+++ b/dmt/templates/main/project_detail.html
@@ -303,7 +303,6 @@
       <th>Target Date</th>
       <th>Status</th>
       <th># Open</th>
-      <th></th>
     </tr>
   </thead>
   
@@ -314,8 +313,6 @@
       <td>{{milestone.target_date|date:"Y-m-d"}}</td>
       <td class="{{milestone.status_class}}">{{milestone.status}}</td>
       <td>{{milestone.num_open_items}}</td>
-      <td><img src="{{GRAPHITE_BASE}}?target=ccnmtl.app.gauges.dmt.milestones.{{milestone.mid}}.hours_logged&target=ccnmtl.app.gauges.dmt.milestones.{{milestone.mid}}.hours_estimated&_salt=1369503684.466&height=10&colorList=%2366cc66%2C%23cc6666&hideLegend=true&hideAxes=true&yMin=0&width=100&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=stacked&from=-1years"
-     width="100" height="10" /></td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
Every once in a while these are interesting and useful, but I'm
feeling like on the whole, the little stripchart graphs of
hours/estimated for every milestone just isn't a useful enough
feature to keep around. LITO's graphite server is slow and the result
is that they slow down loading of whole pages.