### PR TITLE
band-aid fix for infinite loop with linkify filter. PMT #101115

### DIFF
--- a/dmt/main/templatetags/dmttags.py
+++ b/dmt/main/templatetags/dmttags.py
@@ -33,5 +33,5 @@ def interval_to_hours(duration):
 def linkify(value):
     return bleach.linkify(value,
                           skip_pre=True,
-                          parse_email=True,
+                          parse_email=False,
                           tokenizer=HTMLTokenizer)

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -961,6 +961,16 @@ class TestForum(TestCase):
         r = self.c.get(n.get_absolute_url())
         self.assertEquals(r.status_code, 404)
 
+    def test_linkify_infinite_loop(self):
+        # see https://pmt.ccnmtl.columbia.edu/item/101115/
+        n = NodeFactory(body=(
+            '<a href="https://www1.columbia.edu/sec/cu/lweb/reserves/">'
+            'https://www1.columbia.edu/sec/cu/lweb/reserves/</a>. '
+            'Instructors can also email film requests to butlres@lib'
+            'raries.cul.columbia.edu'))
+        r = self.c.get(n.get_absolute_url())
+        self.assertEqual(r.status_code, 200)
+
 
 class TestForumTagViews(TestCase):
     def setUp(self):


### PR DESCRIPTION
Certain text in forum posts seems to be sending linkify into an infinite loop and hanging apache on patches.

still looking into the proper way to fix it, but for now, disabling mailto parsing in the filter
seems to at least make the problem go away temporarily