### PR TITLE
Update date-related packages

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -1118,15 +1118,16 @@ class Item(models.Model):
                 priority_label_f(priority)))
 
     def add_event(self, status, user, comment):
+        now = datetime.now()
         e = Events.objects.create(
             status=status,
-            event_date_time=datetime.now(),
+            event_date_time=now,
             item=self)
         Comment.objects.create(
             event=e,
             username=user.username,
             comment=comment,
-            add_date_time=datetime.now())
+            add_date_time=now)
 
     def setup_default_notification(self):
         self.add_cc(self.owner)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ fuzzywuzzy==0.4.0
 sure==1.2.9
 ipython==3.0.0
 ipdb==0.8
-isodate==0.5.0
+isodate==0.5.1
 SPARQLWrapper==1.6.4
 rdflib==4.1.2
 selenium==2.45.0
@@ -31,8 +31,8 @@ logilab-astng==0.24.3
 astroid==1.2.1
 pylint==1.4.1
 six==1.9.0
-python-dateutil==2.4.0
-pytz==2014.7
+python-dateutil==2.4.2
+pytz==2015.4
 simpleduration==0.1.0
 factory_boy==2.5.2
 python-ldap==2.4.18


### PR DESCRIPTION
* Also, removes an unnecessary calculation of datetime.now()

These changes don't resolve the timezone issue - PMT #101081
A fix for that is coming.