### PR TITLE
Convert timestamp fields to timestamptz - PMT #101081

### DIFF
--- a/dmt/main/migrations/0016_timestamptz.py
+++ b/dmt/main/migrations/0016_timestamptz.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.db import migrations
+
+
+def migrate_timestamptz(tbl, col):
+    """
+    Alter the timestamps to timestamptz, making sure to import
+    them with the proper timezone. Right now the timestamps are in
+    localtime, which is America/New_York, which we can get from
+    settings.TIME_ZONE.
+
+    The resulting fields will be timestamptz, which appear as UTC
+    in the psql console, which Django correctly understands. As a result,
+    there's no longer strange behavior when using Django's timezone
+    functionality such as USE_TZ.
+    """
+
+    # Do nothing unless we're migrating postgresql.
+    if settings.DATABASES['default']['ENGINE'] != \
+       'django.db.backends.postgresql_psycopg2':
+        return migrations.RunPython(migrations.RunPython.noop)
+
+    sql = "ALTER TABLE {:s} ALTER COLUMN {:s} SET DATA TYPE timestamptz " \
+          "USING {:s} AT TIME ZONE '{:s}';"
+    sql = sql.format(tbl, col, col, settings.TIME_ZONE)
+    return migrations.RunSQL(sql)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0015_auto_20150514_0600'),
+    ]
+
+    operations = [
+        migrate_timestamptz('documents', 'last_mod'),
+        migrate_timestamptz('items', 'last_mod'),
+        migrate_timestamptz('nodes', 'added'),
+        migrate_timestamptz('events', 'event_date_time'),
+        migrate_timestamptz('actual_times', 'completed'),
+        migrate_timestamptz('attachment', 'last_mod'),
+        migrate_timestamptz('comments', 'add_date_time'),
+    ]

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -2,6 +2,7 @@ from django import forms
 from django.test import TestCase
 from django.conf import settings
 from django.core import mail
+from django.utils import timezone
 import unittest
 from .factories import (
     UserProfileFactory, ItemFactory, NodeFactory, ProjectFactory,
@@ -553,7 +554,7 @@ class ProjectTest(TestCase):
         i = m.item_set.all()[0]
         self.assertEqual(i.estimated_time.seconds, 0)
 
-    def test_add_item_valid_duration(self):
+    def test_add_item_valid_duration_and_timezone(self):
         m = MilestoneFactory()
         p = m.project
         u = UserProfileFactory()
@@ -565,6 +566,13 @@ class ProjectTest(TestCase):
         self.assertTrue(m.item_set.all().count() > 0)
         i = m.item_set.all()[0]
         self.assertEqual(i.estimated_time.seconds, 7200)
+
+        # Assert that the last_mod time is within ten mins of what
+        # we expect.
+        now = timezone.now()
+        five_mins = timedelta(minutes=5)
+        self.assertTrue(i.last_mod < (now + five_mins))
+        self.assertTrue(i.last_mod > (now - five_mins))
 
     def test_timeline_empty(self):
         p = ProjectFactory()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ fuzzywuzzy==0.4.0
 sure==1.2.9
 ipython==3.0.0
 ipdb==0.8
-isodate==0.5.0
+isodate==0.5.1
 SPARQLWrapper==1.6.4
 rdflib==4.1.2
 selenium==2.45.0
@@ -31,8 +31,8 @@ logilab-astng==0.24.3
 astroid==1.2.1
 pylint==1.4.1
 six==1.9.0
-python-dateutil==2.4.0
-pytz==2014.7
+python-dateutil==2.4.2
+pytz==2015.4
 simpleduration==0.1.0
 factory_boy==2.5.2
 python-ldap==2.4.18


### PR DESCRIPTION
Django doesn't really support PostgreSQL fields of type
`timestamp without time zone`, but it seems like we were using
them because migrating those fields could cause problems in the old
perl PMT. According to the timezone docs it looks like django expects
`timestamp with time zone`:
https://docs.djangoproject.com/en/1.8/topics/i18n/timezones/#database

This includes a postgresql migration that prevents django from
getting confused when we have `USE_TZ = True`.

The big change here is that we're going from timezone-naive
to timezone-aware dates, so I changed all our datetime.now()
calls to timezone.now() as is expected when `USE_TZ = True`:
https://docs.djangoproject.com/en/1.8/topics/i18n/timezones/#concepts