### PR TITLE
Use django-bootstrap3's form rendering tag in all forms

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -119,7 +119,6 @@ INSTALLED_APPS = [
     'compressor',
     'django_markwhat',
     'django_statsd',
-    'bootstrapform',
     'debug_toolbar',
     'waffle',
     'django_jenkins',

--- a/dmt/templates/main/client_filter.html
+++ b/dmt/templates/main/client_filter.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
+
 {% block title %}Clients List{% endblock %}
 
 {% block primarynavtabs %}
@@ -79,7 +80,7 @@
 <p><a class="btn btn-success" href="/client/">Clear Filter</a></p>
 <hr />
 <form action="" method="get">
-  {{ filter.form|bootstrap }}
+  {% bootstrap_form filter.form %}
   <input type="submit" class="btn btn-primary" value="filter" />
 </form>
 </div>

--- a/dmt/templates/main/client_form.html
+++ b/dmt/templates/main/client_form.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 
 {% block content %}
 <h1>Add New Client</h1>
 <form action="." method="post">{% csrf_token %}
 <fieldset>
-{{form|bootstrap}}
+{% bootstrap_form form %}
 
 <div class="button-set">
 <input type="submit" value="Add Client" class="btn btn-primary" />

--- a/dmt/templates/main/group_list.html
+++ b/dmt/templates/main/group_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+
 {% block title %}Groups List{% endblock %}
 
 {% block primarynavtabs %}

--- a/dmt/templates/main/item_form.html
+++ b/dmt/templates/main/item_form.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
+
 {% block title %}Edit Item #{{object.iid}}&ndash;{{object.title}}{% endblock %}
 {% block extraclass %} class="object-form item-form"{% endblock %}
 
@@ -27,7 +28,7 @@
   <div class="item-details">
     <form action="." method="post">{% csrf_token %}
     <fieldset>
-    {{form|bootstrap}}
+    {% bootstrap_form form %}
     <div class="button-set">
     <a href="{{object.get_absolute_url}}" class="btn btn-default">Cancel</a>
     <input type="submit" value="Save" class="btn btn-primary" />

--- a/dmt/templates/main/milestone_form.html
+++ b/dmt/templates/main/milestone_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 
 {% block title %}Edit Milestone&ndash;{{object.name}}{% endblock %}
 {% block extraclass %} class="project-form"{% endblock %}
@@ -20,7 +20,7 @@
 <form action="." method="post">{% csrf_token %}
 <fieldset>
 
-{{form|bootstrap}}
+{% bootstrap_form form %}
 
 <div class="button-set">
 <a href="{{object.get_absolute_url}}" class="btn btn-default">Cancel</a>

--- a/dmt/templates/main/my_projects.html
+++ b/dmt/templates/main/my_projects.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
 
 {% block title %}My Projects{% endblock %}
 

--- a/dmt/templates/main/node_form.html
+++ b/dmt/templates/main/node_form.html
@@ -1,18 +1,18 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 
 {% block content %}
 <p class="pull-right"><a class="btn btn-xs btn-danger"
-												 href="{{object.get_absolute_url}}delete/"><span class="glyphicon
-																										 glyphicon-trash"></span>
+						 href="{{object.get_absolute_url}}delete/"><span class="glyphicon
+																				glyphicon-trash"></span>
 		delete</a></p>
 
 <form action="." method="post">{% csrf_token %}
-<fieldset><legend>Edit Forum Post</legend>
-{{form|bootstrap}}
+    <fieldset><legend>Edit Forum Post</legend>
+        {% bootstrap_form form %}
 
-<a href="{{object.get_absolute_url}}" class="btn btn-default">Cancel</a>
-<input type="submit" value="Save" class="btn btn-primary" />
-</fieldset>
+        <a href="{{object.get_absolute_url}}" class="btn btn-default">Cancel</a>
+        <input type="submit" value="Save" class="btn btn-primary" />
+    </fieldset>
 </form>
 {% endblock %}

--- a/dmt/templates/main/project_filter.html
+++ b/dmt/templates/main/project_filter.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+
+{% load bootstrap3 %}
+
 {% block extraclass %} class="project-page"{% endblock %}
 
 {% block title %}All Projects{% endblock %}
@@ -63,7 +65,7 @@
     <a href="/project/" class="btn btn-default">Cancel</a>
   </div>
 
-  {{ filter.form|bootstrap }}
+  {% bootstrap_form filter.form %}
 
   <div class="button-set">
     <input type="submit" class="btn btn-primary" value="Filter" />

--- a/dmt/templates/main/project_form.html
+++ b/dmt/templates/main/project_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 
 {% block title %}Project: Create new project{% endblock %}
 {% block extraclass %} class="project-form"{% endblock %}
@@ -15,7 +15,7 @@
 <form action="." method="post">{% csrf_token %}
 <fieldset>
 
-{{form|bootstrap}}
+{% bootstrap_form form %}
 
 <div class="button-set">
 <input type="submit" value="Save project" class="btn btn-primary" />

--- a/dmt/templates/main/project_update_form.html
+++ b/dmt/templates/main/project_update_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 
 {% block title %}Project: Edit {{object.name}}{% endblock %}
 {% block extraclass %} class="project-form"{% endblock %}
@@ -13,7 +13,7 @@
 <form action="." method="post">{% csrf_token %}
 <fieldset>
 
-{{form|bootstrap}}
+{% bootstrap_form form %}
 
 <div class="button-set">
 <a href="{% url 'project_detail' object.pid %}" class="btn btn-default">Cancel</a>

--- a/dmt/templates/main/statusupdate_form.html
+++ b/dmt/templates/main/statusupdate_form.html
@@ -1,21 +1,18 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 
 {% block content %}
 
 <p class="pull-right"><a class="btn btn-xs btn-danger"
-												 href="delete/"><span class="glyphicon
-																										 glyphicon-trash"></span>
-		delete</a></p>
+                         href="delete/"><span class="glyphicon
+                                                     glyphicon-trash"></span>
+        delete</a></p>
 
 <form action="." method="post">{% csrf_token %}
-<fieldset><legend>Edit Status Update</legend>
-{{form|bootstrap}}
-<input type="submit" class="btn btn-primary" value="save" />
-</fieldset>
+    <fieldset><legend>Edit Status Update</legend>
+        {% bootstrap_form form %}
+        <input type="submit" class="btn btn-primary" value="save" />
+    </fieldset>
 </form>
-
-
-
 
 {% endblock %}

--- a/dmt/templates/main/user_deactivate.html
+++ b/dmt/templates/main/user_deactivate.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
 
 {% block content %}
 {% if request.user.is_superuser %}

--- a/dmt/templates/main/user_filter.html
+++ b/dmt/templates/main/user_filter.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+
+{% load bootstrap3 %}
 
 {% block title %}All Users{% endblock %}
 
@@ -54,7 +55,7 @@
 <div class="tab-pane fade object-form" id="filter">
 
 <form action="" method="get">
-  {{ filter.form|bootstrap }}
+  {% bootstrap_form filter.form %}
 
   <div class="button-set">
     <input type="submit" class="btn btn-primary" value="Filter" />

--- a/dmt/templates/main/user_form.html
+++ b/dmt/templates/main/user_form.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% load bootstrap %}
+{% load bootstrap3 %}
+
 {% block title %}Edit User Profile &ndash;{{object.fullname}}{% endblock %}
 {% block extraclass %} class="object-form"{% endblock %}
 
@@ -29,7 +30,7 @@
     <form action="." method="post">{% csrf_token %}
     <fieldset>
     
-    {{form|bootstrap}}
+    {% bootstrap_form form %}
     
     <div class="button-set">
     <a href="{{object.get_absolute_url}}" class="btn btn-default">Cancel</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,6 @@ django-appconf==1.0.1
 django-compressor==1.5
 django-statsd-mozilla==0.3.14
 raven==5.2.0
-django-bootstrap-form==3.2
 django-debug-toolbar==1.3.0
 django-waffle==0.10.1
 django-jenkins==0.17.0
@@ -82,7 +81,7 @@ django-templatetag-sugar==1.0
 django-taggit-templatetags2==1.4.0
 django-celery==3.1.16
 django-casper==0.0.2c
-django-bootstrap3==5.2.0
+django-bootstrap3==5.4.0
 django-emoji==2.0.0
 django-behave==0.1.4
 django-oauth2-provider==0.2.6.1


### PR DESCRIPTION
For consistency, we should stick to one package for rendering
bootstrap forms. django-bootstrap3 is a little more active than
django-bootstrap-form, and is more likely to support more bootstrap
features.

There were also a few places where no bootstrap library was being
used, even though it was loaded, so I've removed those.