### PR TITLE
Add missing title tags to reports

### DIFF
--- a/dmt/templates/report/passed_milestones.html
+++ b/dmt/templates/report/passed_milestones.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Passed Milestones{% endblock %}
+
 {% block content %}
 <ul class="breadcrumb">
   <li><a href="/"><span class="glyphicon glyphicon-home"></span></a></li>

--- a/dmt/templates/report/resolved.html
+++ b/dmt/templates/report/resolved.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Resolved Items{% endblock %}
+
 {% block content %}
 <ul class="breadcrumb">
   <li><a href="/"><span class="glyphicon glyphicon-home"></span></a></li>

--- a/dmt/templates/report/user_weekly.html
+++ b/dmt/templates/report/user_weekly.html
@@ -1,9 +1,8 @@
 {% extends 'base.html' %}
 {% load dmttags %}
 
-{% block title %}User Weekly
- Report: <a href="{{u.get_absolute_url}}">{{u.fullname}}</a>
- ({{week_start}} to {{week_end}})
+{% block title %}
+User Weekly Report: {{u.fullname}} ({{week_start}} to {{week_end}})
 {% endblock %}
 
 {% block primarynavtabs %}

--- a/dmt/templates/report/user_yearly.html
+++ b/dmt/templates/report/user_yearly.html
@@ -1,9 +1,8 @@
 {% extends 'base.html' %}
 {% load dmttags %}
 
-{% block title %}User Yearly
- Report: <a href="{{u.get_absolute_url}}">{{u.fullname}}</a>
- ({{interval_start}} to {{interval_end}})
+{% block title %}
+User Yearly Report: {{u.fullname}} ({{interval_start}} to {{interval_end}})
 {% endblock %}
 
 {% block primarynavtabs %}


### PR DESCRIPTION
Also I removed the `<a>` tag from the title,
since you can't click on it there and it was
rendering as text.