### PR TITLE
Use timezone.now() instead of datetime.now()

### DIFF
--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt
@@ -9,7 +10,7 @@ from rest_framework import generics, viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from simpleduration import Duration, InvalidDuration
-from datetime import datetime, timedelta
+from datetime import timedelta
 from dateutil import parser
 
 from dmt.main.models import (
@@ -264,9 +265,9 @@ class ProjectMilestoneList(generics.ListCreateAPIView):
 
 def process_completed(completed=None):
     if completed == 'last':
-        return datetime.now() - timedelta(days=7)
+        return timezone.now() - timedelta(days=7)
     if completed == 'before_last':
-        return datetime.now() - timedelta(days=14)
+        return timezone.now() - timedelta(days=14)
     return completed
 
 
@@ -296,7 +297,7 @@ class AddTrackerView(View):
             owner_user=user.user, assigned_user=user.user,
             title=task, status='VERIFIED',
             priority=1, target_date=milestone.target_date,
-            last_mod=datetime.now(),
+            last_mod=timezone.now(),
             estimated_time=td)
         if client_uni != '':
             r = Client.objects.filter(

--- a/dmt/main/tasks.py
+++ b/dmt/main/tasks.py
@@ -1,8 +1,9 @@
 from celery.decorators import periodic_task, task
 from celery.task.schedules import crontab
 from django.db import connection
+from django.utils import timezone
 from django_statsd.clients import statsd
-from datetime import datetime, timedelta
+from datetime import timedelta
 import time
 from .models import Item, ActualTime, interval_sum
 from .models import UserProfile, Milestone
@@ -72,7 +73,7 @@ def estimates_report():
 
 
 def hours_logged(weeks=1):
-    now = datetime.now()
+    now = timezone.now()
     one_week_ago = now - timedelta(weeks=weeks)
     # active projects
     try:
@@ -140,7 +141,7 @@ def total_hours_estimated_vs_logged():
 
 @periodic_task(run_every=crontab(hour=1, minute=0, day_of_week='*'))
 def close_passed_milestones():
-    now = datetime.now()
+    now = timezone.now()
     for milestone in Milestone.objects.filter(
             status='OPEN', target_date__lt=now):
         milestone.update_milestone()
@@ -164,7 +165,7 @@ def bump_someday_maybe_target_dates():
     should never actually reach a target date.
     so once a day, we take any that are upcoming
     and push them far into the future again. """
-    now = datetime.now()
+    now = timezone.now()
     upcoming = now + timedelta(weeks=4)
     future = now + timedelta(weeks=52)
     for m in Milestone.objects.filter(

--- a/dmt/main/tests/factories.py
+++ b/dmt/main/tests/factories.py
@@ -2,6 +2,7 @@ import factory
 from datetime import datetime, timedelta
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
+from django.utils import timezone
 from django.utils.timezone import utc
 from dmt.main.models import UserProfile, Project, Milestone, Item
 from dmt.main.models import Comment, Events, Node, ActualTime, StatusUpdate
@@ -54,7 +55,7 @@ class MilestoneFactory(factory.DjangoModelFactory):
     mid = factory.Sequence(lambda n: n)
     project = factory.SubFactory(ProjectFactory)
     name = factory.Sequence(lambda n: 'Test Milestone {0}'.format(n))
-    target_date = datetime.now().date() + timedelta(days=3650)
+    target_date = timezone.now().date() + timedelta(days=3650)
     status = "OPEN"
 
 

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -11,6 +11,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.shortcuts import render_to_response
 from django.template import RequestContext
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView, View
 from django.views.generic.detail import DetailView
@@ -36,7 +37,7 @@ from dmt.main.utils import new_duration, safe_basename
 from dmt.report.mixins import PrevNextWeekMixin, RangeOffsetMixin
 
 from django_markwhat.templatetags.markup import commonmark
-from datetime import datetime, timedelta
+from datetime import timedelta
 from simpleduration import Duration, InvalidDuration
 from hashlib import sha1
 import time
@@ -971,7 +972,7 @@ class ProjectAddMilestoneView(LoggedInMixin, View):
         Milestone.objects.create(
             project=project, name=name,
             status='OPEN',
-            target_date=request.POST.get('target_date', datetime.now().date())
+            target_date=request.POST.get('target_date', timezone.now().date())
         )
         return HttpResponseRedirect(project.get_absolute_url())
 
@@ -1031,7 +1032,7 @@ class DashboardView(LoggedInMixin, TemplateView):
             total_hours_estimated - sm_hours_estimated)
 
         # recent/upcoming milestones
-        now = datetime.now()
+        now = timezone.now()
         four_weeks_ago = now - timedelta(weeks=4)
         four_weeks_future = now + timedelta(weeks=4)
         two_weeks_ago = now - timedelta(weeks=2)
@@ -1117,7 +1118,7 @@ class SignS3View(LoggedInMixin, View):
         elif 'gif' in mime_type:
             extension = ".gif"
 
-        now = datetime.now()
+        now = timezone.now()
         uid = str(uuid.uuid4())
         object_name = "%04d/%02d/%02d/%02d/%s-%s%s" % (
             now.year, now.month, now.day,
@@ -1173,7 +1174,7 @@ class ItemAddAttachmentView(LoggedInMixin, View):
             description=description,
             filename=filename,
             type=atype,
-            last_mod=datetime.now(),
+            last_mod=timezone.now(),
         )
         return HttpResponseRedirect(item.get_absolute_url())
 
@@ -1283,7 +1284,7 @@ class AddTrackersView(LoggedInMixin, FormSetView):
             owner_user=user, assigned_user=user,
             title=task, status='VERIFIED',
             priority=1, target_date=milestone.target_date,
-            last_mod=datetime.now(),
+            last_mod=timezone.now(),
             estimated_time=td)
 
         if client_uni:

--- a/dmt/report/views.py
+++ b/dmt/report/views.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView, View
+from django.utils import timezone
 
 from dmt.main.models import UserProfile, Item, Milestone, Project
 from dmt.main.views import LoggedInMixin
@@ -235,7 +236,7 @@ class PassedMilestonesView(LoggedInMixin, TemplateView):
         context = super(PassedMilestonesView, self).get_context_data(**kwargs)
         context['items'] = Item.objects.filter(status='RESOLVED')
 
-        now = datetime.now()
+        now = timezone.now()
         context['milestones'] = Milestone.objects.filter(
             status='OPEN',
             target_date__lt=now,


### PR DESCRIPTION
Because DMT has switched to using timezone-aware datetimes
(see PR #421), it should be calling timezone.now() instead
of datetime.now().

Referencing PMT #101424