### PR TITLE
Specify license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dmt",
   "version": "0.1.0",
   "description": "Project management tool",
+  "license": "GPL-2.0+",
   "scripts": {
     "test": "./node_modules/karma/bin/karma start"
   },


### PR DESCRIPTION
npm throwing a warning because it was missing this, so
we might as well add it.