### PR TITLE
Use timezone-aware dates when calculating prev/next week - PMT #101424

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -83,14 +83,10 @@ class UserProfile(models.Model):
         return sorted(set(list(projects)), key=lambda x: x.name.lower())
 
     def resolve_times_for_interval(self, start, end):
-        # Handle dates as well as datetimes
-        start_date = getattr(start, 'date', start)
-        end_date = getattr(end, 'date', end)
-
         return ActualTime.objects.filter(
             resolver=self,
-            completed__gt=start_date,
-            completed__lte=end_date
+            completed__gt=start,
+            completed__lte=end
         ).select_related('item', 'item__milestone', 'item__milestone__project')
 
     def total_resolve_times(self):
@@ -341,8 +337,8 @@ class ProjectUser(object):
                 a.actual_time for a in ActualTime.objects.filter(
                     resolver=self.user,
                     item__milestone__project=self.project,
-                    completed__gt=start.date,
-                    completed__lte=end.date)])
+                    completed__gt=start,
+                    completed__lte=end)])
 
 
 # before putting in the IntervalField, there were some

--- a/dmt/report/tests/test_mixins.py
+++ b/dmt/report/tests/test_mixins.py
@@ -1,6 +1,6 @@
-from dateutil import parser
 from datetime import date, timedelta
 from django.test import TestCase
+from django.utils.dateparse import parse_datetime
 from dmt.report.mixins import RangeOffsetMixin, PrevNextWeekMixin
 
 
@@ -9,20 +9,20 @@ class PrevNextWeekMixinTests(TestCase):
         self.mixin = PrevNextWeekMixin()
 
     def test_calc_weeks(self):
-        now = parser.parse('Nov 1 2014 12pm')
+        now = parse_datetime('2014-11-01 00:00:00')
         self.mixin.calc_weeks(now)
         self.assertEqual(
             self.mixin.week_start,
-            parser.parse('Oct 27 2014 12pm'))
+            parse_datetime('2014-10-27 00:00:00'))
         self.assertEqual(
             self.mixin.week_end,
-            parser.parse('Nov 2 2014 12pm'))
+            parse_datetime('2014-11-02 23:59:59'))
         self.assertEqual(
             self.mixin.prev_week,
-            parser.parse('Oct 20 2014 12pm'))
+            parse_datetime('2014-10-20 00:00:00'))
         self.assertEqual(
             self.mixin.next_week,
-            parser.parse('Nov 3 2014 12pm'))
+            parse_datetime('2014-11-03 00:00:00'))
 
 
 class RangeOffsetMixinTests(TestCase):


### PR DESCRIPTION
There were two problems with the week calculation addressed here:

* The 'end of the week' was calculated at 12:00 on Sunday
  (the middle of the day), instead of the end of the day
  -- 23:59.
* The PrevNextWeekMixin was treating the dates as localtime, not
  UTC, which is now what they are in the database. That means that,
  if you make a change late on sunday night, which is actually
  early the next week in UTC, it would be calculated as being in
  the wrong week.