### PR TITLE
Fix time calculation bug in PrevNextWeekMixin - PMT #101552

### DIFF
--- a/dmt/report/mixins.py
+++ b/dmt/report/mixins.py
@@ -1,6 +1,7 @@
 import pytz
 from datetime import date, datetime, timedelta
 from django.conf import settings
+from django.utils import timezone
 from django.utils.dateparse import parse_date
 
 
@@ -23,7 +24,11 @@ class PrevNextWeekMixin(object):
             # https://docs.djangoproject.com/en/1.8/topics/i18n/timezones/#usage
             aware = pytz.timezone(settings.TIME_ZONE).localize(naive,
                                                                is_dst=None)
-            self.calc_weeks(aware)
+        else:
+            # There was no date param in the URL, so use now.
+            aware = timezone.now()
+
+        self.calc_weeks(aware)
 
     def get_context_data(self, *args, **kwargs):
         self.get_params()
@@ -33,7 +38,9 @@ class PrevNextWeekMixin(object):
 
     def calc_weeks(self, now):
         self.now = now
-        self.week_start = now + timedelta(days=-self.now.weekday())
+        # Set week_start to the beginning of Monday.
+        monday = now + timedelta(days=-self.now.weekday())
+        self.week_start = datetime.combine(monday, datetime.min.time())
 
         # This week ends at 11:59:59 on Sunday night.
         self.week_end = self.week_start + timedelta(days=6,

--- a/dmt/report/tests/test_mixins.py
+++ b/dmt/report/tests/test_mixins.py
@@ -26,6 +26,13 @@ class PrevNextWeekMixinTests(TestCase):
             self.mixin.next_week,
             parse_datetime('2014-11-03 00:00:00'))
 
+        now = parse_datetime('2014-11-01 11:25:28')
+        self.mixin.calc_weeks(now)
+        self.assertEqual(
+            self.mixin.week_start,
+            parse_datetime('2014-10-27 00:00:00'),
+            'It calculates the beginning of the week accurately')
+
 
 class RangeOffsetMixinTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
When no URL param was provided, the current time was having an effect on the reported trackers on the weekly report mixin. To fix the issue, I'm calling calc_weeks() and clearing out the time value to calculate the beginning of the week accurately.