### PR TITLE
Use the primary group for reporting - PMT #95814

### DIFF
--- a/dmt/main/templatetags/dmttags.py
+++ b/dmt/main/templatetags/dmttags.py
@@ -1,7 +1,9 @@
 import bleach
 from django import template
 from html5lib.tokenizer import HTMLTokenizer
+from dmt.main.models import InGroup
 import dmt.main.utils as utils
+
 
 register = template.Library()
 
@@ -35,3 +37,9 @@ def linkify(value):
                           skip_pre=True,
                           parse_email=False,
                           tokenizer=HTMLTokenizer)
+
+
+@register.filter
+def verbose_group_name(group_user):
+    """Given a group's UserProfile, return its name."""
+    return InGroup.verbose_name(group_user.fullname)

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -1107,6 +1107,8 @@ class GroupTest(TestCase):
         self.u.save()
         self.client.login(username="testuser", password="test")
         self.group = GroupFactory()
+        self.u.userprofile.primary_group = self.group.grp
+        self.u.userprofile.save()
 
     def test_group_list(self):
         response = self.client.get(reverse('group_list'))
@@ -1117,6 +1119,22 @@ class GroupTest(TestCase):
         response = self.client.get(
             reverse('group_detail', args=(self.group.grp.username,)))
         self.assertEqual(response.status_code, 200)
+
+        self.assertTrue(
+            self.u.userprofile in response.context['primary_members'])
+        self.assertEqual(
+            response.context['primary_members'].count(), 1)
+
+        self.assertTrue(
+            self.group.username in response.context['other_members'])
+        self.assertEqual(
+            response.context['other_members'].count(), 1)
+
+        self.assertTrue(
+            self.u.userprofile in response.context['eligible_users'])
+        self.assertEqual(
+            response.context['eligible_users'].count(), 1)
+
         self.assertTrue(str(self.group) in response.content)
         self.assertTrue(self.group.username.username in response.content)
 

--- a/dmt/report/models.py
+++ b/dmt/report/models.py
@@ -22,19 +22,14 @@ class StaffReportCalculator(object):
             try:
                 group_user = UserProfile.objects.get(username="grp_" + grp)
             except UserProfile.DoesNotExist:
+                # If we can't find a group under this name, just
+                # continue to the next iteration of the loop.
                 continue
 
-            for user in group_user.users_in_group():
-                existing_user = \
-                    [x for x in user_data
-                     if x['user'].username == user.username]
-                if existing_user:
-                    # This user is already in our user_data list. This means
-                    # they belong to more than one group that we're reporting
-                    # on. In this case, it's safe to just skip this duplicate
-                    # entry.
-                    continue
+            # Find all users whose primary group is the selected group.
+            users = UserProfile.objects.filter(primary_group=group_user)
 
+            for user in users:
                 user_time = user.interval_time(start, end)
                 group_name = InGroup.verbose_name(group_user.fullname)
                 group_username = group_user.username

--- a/dmt/templates/main/group_detail.html
+++ b/dmt/templates/main/group_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% load dmttags %}
 
-{% block title %}Group: {{object.readable_group_name}}{% endblock %}
+{% block title %}Group: {{object|verbose_group_name}}{% endblock %}
 
 {% block primarynavtabs %}
 {% endblock %}
@@ -13,14 +14,14 @@
 <ul class="breadcrumb">
   <li><a href="/"><span class="glyphicon glyphicon-home"></span></a></li>
   <li><a href="{% url 'group_list' %}">Groups</a></li>
-  <li class="active">{{ group_name }}</li>
+  <li class="active">{{ object|verbose_group_name }}</li>
 </ul>
 
-<h1>Group: {{ group_name }}</h1>
+<h1>Group: {{ object|verbose_group_name }}</h1>
 
-<h3>Members</h3>
+<h3>Primary Members</h3>
 <table class="table table-striped table-condensed">
-{% for user in object_list %}
+{% for user in primary_members %}
 <tr>
     <td>
         <a href="{% url 'user_detail' user.username %}">
@@ -28,25 +29,55 @@
         </a>
     </td>
 		<td>
-			<form action="{% url 'remove_user_from_group' group.username %}"
-						method="post">{% csrf_token %}
+			<form action="{% url 'remove_user_from_group' object.username %}"
+				  method="post">{% csrf_token %}
 				<input type="hidden" name="username" value="{{user.username}}" />
 			<input type="submit" class="btn btn-warning pull-right btn-xs"
-						 value="remove" />
+				   value="remove" />
 			</form>
 		</td>
 </tr>
 {% endfor %}
 </table>
 
-<form action="add_user/" method="post">{% csrf_token %}
-<fieldset><legend>Add User to this Group</legend>
-<select name="username" class="form-control">
-{% for user in eligible_users %}
-<option value="{{user.username}}">{{user.fullname}}</option>
+{% if other_members %}
+<h3>Other Members</h3>
+<table class="table table-striped table-condensed">
+{% for user in other_members %}
+<tr>
+    <td>
+        <a href="{% url 'user_detail' user.username %}">
+            {{ user.fullname }}
+        </a>
+    </td>
+        <td>
+            <form action="{% url 'remove_user_from_group' object.username %}"
+                  method="post">{% csrf_token %}
+                <input type="hidden" name="username" value="{{user.username}}" />
+            <input type="submit" class="btn btn-warning pull-right btn-xs"
+                   value="remove" />
+            </form>
+        </td>
+</tr>
 {% endfor %}
-</select><input type="submit" class="btn btn-primary" value="add user" />
-<fieldset>
+</table>
+{% endif %}
+
+<form class="form-inline" action="add_user/" method="post">
+    {% csrf_token %}
+    <h3>
+        Add User to this Group (as <strong>other</strong> member)
+    </h3>
+        <div class="form-group">
+            <select name="username" class="form-control">
+                {% for user in eligible_users %}
+                <option value="{{user.username}}">{{user.fullname}}</option>
+                {% endfor %}
+            </select>
+        </div>
+    <button type="submit"  class="btn btn-primary">
+        add user
+    </button>
 </form>
 
 {% endblock %}

--- a/dmt/templates/main/user_detail.html
+++ b/dmt/templates/main/user_detail.html
@@ -70,27 +70,28 @@
 
 
 
-<dl class="dl-horizontal clearfix">
-{% with object.user_groups as groups %}
-{% if groups %}
-<dt>Groups:</dt>
-<dd>
-    {% for g in groups %}
-    <a href="{% url 'group_detail' g.username %}">
-        {{g.group_fullname}}</a>{% if not forloop.last %}, {% endif %}
-    {% endfor %}
-</dd>
-{% endif %}
-{% endwith %}
-
-{% if object.primary_group %}
-<dt>Primary Group:</dt>
-<dd>
-    <a href="{% url 'group_detail' object.primary_group.username %}"
-       >{{object.primary_group.group_fullname}}</a>
-</dd>
-{% endif %}
-</dl>
+    <dl class="dl-horizontal clearfix">
+        {% if object.primary_group %}
+        <dt>Primary Group:</dt>
+        <dd>
+            <a href="{% url 'group_detail' object.primary_group.username %}"
+               >{{object.primary_group.group_fullname}}</a>
+        </dd>
+        {% endif %}
+        {% with object.user_groups as groups %}
+        {% if groups %}
+        <dt>Other Groups:</dt>
+        <dd>
+            {% for g in groups %}
+            {% if object.primary_group != g %}
+            <a href="{% url 'group_detail' g.username %}">
+                {{g.group_fullname}}</a>{% if not forloop.last %}, {% endif %}
+            {% endif %}
+            {% endfor %}
+        </dd>
+        {% endif %}
+        {% endwith %}
+    </dl>
 
 
 <dl class="dl-horizontal clearfix">


### PR DESCRIPTION
Now we have primary groups and what I'm calling
"Other" groups, but we could change this to "Secondary"
if that's clearer.

The group detail page displays the primary members and the
other members, and allows you to add other members to the
selected group. Each user's primary group can be edited on
their profile page.

The staff report now reports on the user's "primary" group, instead
of an arbitrary "other" group.