### PR TITLE
Replace calls to datetime.today with timezone.now

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from datetime import timedelta, datetime
+from datetime import timedelta
 from dateutil import parser
 from interval.fields import IntervalField
 from taggit.managers import TaggableManager
@@ -64,14 +64,14 @@ class UserProfile(models.Model):
                    for a in self.resolve_times_for_interval(start, end))
 
     def has_recent_active_projects(self):
-        now = datetime.today()
+        now = timezone.now()
         start = now - timedelta(weeks=5)
         return self.actualtime_set.filter(
             completed__gte=start, completed__lte=now).count() > 0
 
     def recent_active_projects(self):
         """ any projects touched in the last year """
-        now = datetime.today()
+        now = timezone.now()
         start = now - timedelta(weeks=5)
         projects = Project.objects.raw(
             'SELECT distinct m.pid as pid '
@@ -211,7 +211,7 @@ class UserProfile(models.Model):
         return self.statusupdate_set.all()[:count]
 
     def progress_report(self):
-        now = datetime.today()
+        now = timezone.now()
         week_start = now + timedelta(days=-now.weekday())
         hours_logged = self.interval_time(
             week_start,
@@ -483,7 +483,7 @@ class Project(models.Model):
 
         r = self.milestone_set.filter(
             status='OPEN',
-            target_date__gte=datetime.today())
+            target_date__gte=timezone.now())
         if r.count():
             return r.order_by('target_date')[0]
         # there aren't any upcoming open milestones, but we need

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -214,7 +214,7 @@ class ItemTest(TestCase):
         self.assertEqual(i.status_display(), 'FIXED')
 
     def test_target_date_status(self):
-        now = datetime.now()
+        now = timezone.now()
         i = ItemFactory(target_date=(now + timedelta(days=8)).date())
         self.assertEqual(i.target_date_status(), "ok")
 

--- a/dmt/main/tests/test_tasks.py
+++ b/dmt/main/tests/test_tasks.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
+from django.utils import timezone
 from .factories import MilestoneFactory
-from datetime import datetime, timedelta
+from datetime import timedelta
 from dmt.main.models import Milestone
 from dmt.main.tasks import (
     get_item_counts_by_status, item_counts, hours_logged,
@@ -31,9 +32,9 @@ class TestBumpSomedayMaybe(TestCase):
         m = MilestoneFactory(
             name="Someday/Maybe",
             status="OPEN",
-            target_date=datetime.now().date())
+            target_date=timezone.now().date())
         bump_someday_maybe_target_dates()
         m2 = Milestone.objects.get(mid=m.mid)
         self.assertEqual(
             m2.target_date,
-            (datetime.now() + timedelta(weeks=52)).date())
+            (timezone.now() + timedelta(weeks=52)).date())

--- a/dmt/main/tests/test_timeline.py
+++ b/dmt/main/tests/test_timeline.py
@@ -136,7 +136,7 @@ class TestTimeLineActualTime(unittest.TestCase):
 class DummyStatus(object):
     def __init__(self):
         self.user = "status user"
-        self.added = datetime.now().date()
+        self.added = timezone.now().date()
         self.body = "body"
 
 
@@ -175,7 +175,7 @@ class TestTimeLinePost(unittest.TestCase):
 
 class DummyMilestone(object):
     def __init__(self):
-        self.target_date = datetime.now().date()
+        self.target_date = timezone.now().date()
         self.name = "milestone name"
 
     def get_absolute_url(self):

--- a/dmt/report/mixins.py
+++ b/dmt/report/mixins.py
@@ -12,7 +12,7 @@ class PrevNextWeekMixin(object):
     """
 
     def __init__(self):
-        self.calc_weeks(datetime.today())
+        self.calc_weeks(timezone.now())
 
     def get_params(self):
         if self.request.GET.get('date', None):

--- a/dmt/report/tests/test_models.py
+++ b/dmt/report/tests/test_models.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.test import TestCase
 from django.conf import settings
+from django.utils import timezone
 import unittest
 
 from dmt.report.models import (
@@ -11,7 +12,7 @@ from dmt.report.models import (
 
 class ActiveProjectsCalculatorTests(TestCase):
     def setUp(self):
-        now = datetime.today()
+        now = timezone.now()
         self.interval_start = now - timedelta(days=365)
         self.interval_end = self.interval_start + timedelta(days=365)
 
@@ -26,7 +27,7 @@ class ActiveProjectsCalculatorTests(TestCase):
 
 class StaffReportCalculatorTests(TestCase):
     def setUp(self):
-        now = datetime.today()
+        now = timezone.now()
         self.week_start = now + timedelta(days=-now.weekday())
         self.week_end = self.week_start + timedelta(days=6)
 
@@ -41,7 +42,7 @@ class StaffReportCalculatorTests(TestCase):
 
 class WeeklySummaryReportCalculatorTests(TestCase):
     def setUp(self):
-        now = datetime.today()
+        now = timezone.now()
         self.week_start = now + timedelta(days=-now.weekday())
         self.week_end = self.week_start + timedelta(days=6)
 

--- a/dmt/report/views.py
+++ b/dmt/report/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView, View
@@ -90,7 +90,7 @@ class UserYearlyView(LoggedInMixin, TemplateView):
         context = super(UserYearlyView, self).get_context_data(**kwargs)
         username = kwargs['pk']
         user = get_object_or_404(UserProfile, username=username)
-        now = datetime.today()
+        now = timezone.now()
         interval_start = now + timedelta(days=-365)
         interval_end = now
         data = user.weekly_report(interval_start, interval_end)


### PR DESCRIPTION
I noticed that "Weekly Hours Logged" on the index page wasn't
logging anything on Monday, because it's using timezone-naive
datetime in UserProfile.progress_report().

This commit replaces all calls to datetime.today() and datetime.now()
(unless actually testing a naive timestamp), with timezone.now().