### PR TITLE
Fix progress report week calculation

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from datetime import timedelta
+from datetime import datetime, timedelta
 from dateutil import parser
 from interval.fields import IntervalField
 from taggit.managers import TaggableManager
@@ -212,7 +212,8 @@ class UserProfile(models.Model):
 
     def progress_report(self):
         now = timezone.now()
-        week_start = now + timedelta(days=-now.weekday())
+        monday = now + timedelta(days=-now.weekday())
+        week_start = datetime.combine(monday, datetime.min.time())
         hours_logged = self.interval_time(
             week_start,
             week_start + timedelta(days=7))

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -129,6 +129,15 @@ class UserModelTest(TestCase):
         u = UserProfileFactory(grp=True)
         self.assertTrue(u.get_absolute_url().startswith("/group"))
 
+    def test_progress_report(self):
+        u = UserProfileFactory()
+        d = u.progress_report()
+        self.assertEqual(d['hours_logged'], 0)
+        self.assertEqual(d['week_percentage'], 0)
+        self.assertEqual(d['target_hours'], 14)
+        self.assertEqual(d['target_percentage'], 40)
+        self.assertEqual(d['behind'], True)
+
 
 class ProjectUserTest(TestCase):
     def test_completed_time_for_interval(self):


### PR DESCRIPTION
This fixes a bug where the "Weekly hours logged" on the front page
doesn't include all of the necessary times as shown on the user weekly
report page.