### PR TITLE
Convert IntervalField to Django's builtin DurationField

### DIFF
--- a/dmt/api/tests/test_views.py
+++ b/dmt/api/tests/test_views.py
@@ -292,7 +292,7 @@ class ExternalAddItemTests(APITestCase):
         self.assertTrue(self.owner.username in r.data.get('assigned_to'))
         self.assertTrue(self.debug_info in r.data.get('description'))
         self.assertTrue(unicode(self.milestone.pk) in r.data.get('milestone'))
-        self.assertEqual(r.data.get('estimated_time'), '1:00:00')
+        self.assertEqual(r.data.get('estimated_time'), '01:00:00')
         self.assertEqual(r.data.get('target_date'), self.target_date)
 
     def test_post_redirects_client(self):

--- a/dmt/main/migrations/0020_auto_20150715_1649.py
+++ b/dmt/main/migrations/0020_auto_20150715_1649.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0019_auto_20150605_1607'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='actualtime',
+            name='actual_time',
+            field=models.DurationField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='item',
+            name='estimated_time',
+            field=models.DurationField(null=True, blank=True),
+        ),
+    ]

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -8,7 +8,6 @@ from django.core.urlresolvers import reverse
 from django.utils import timezone
 from datetime import datetime, timedelta
 from dateutil import parser
-from interval.fields import IntervalField
 from taggit.managers import TaggableManager
 from django.core.mail import send_mail
 from django_statsd.clients import statsd
@@ -940,7 +939,7 @@ class Item(models.Model):
     r_status = models.CharField(max_length=16, blank=True)
     last_mod = models.DateTimeField(null=True, blank=True)
     target_date = models.DateField(null=True, blank=True)
-    estimated_time = IntervalField(blank=True, null=True)
+    estimated_time = models.DurationField(blank=True, null=True)
     url = models.TextField(blank=True)
 
     tags = TaggableManager()
@@ -1498,7 +1497,7 @@ class ActualTime(models.Model):
     item = models.ForeignKey(Item, null=False, db_column='iid')
     resolver = models.ForeignKey(UserProfile, db_column='resolver')
     user = models.ForeignKey(User, null=True)
-    actual_time = IntervalField(null=True, blank=True)
+    actual_time = models.DurationField(null=True, blank=True)
     completed = models.DateTimeField(primary_key=True)
 
     class Meta:

--- a/dmt/main/tests/factories.py
+++ b/dmt/main/tests/factories.py
@@ -119,7 +119,7 @@ class ActualTimeFactory(factory.DjangoModelFactory):
 
     item = factory.SubFactory(ItemFactory)
     resolver = factory.SubFactory(UserProfileFactory)
-    actual_time = timedelta(hours=1).total_seconds()
+    actual_time = timedelta(hours=1)
     completed = datetime(2013, 12, 20).replace(tzinfo=utc)
 
 

--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -125,7 +125,6 @@ INSTALLED_APPS = [
     'smoketest',
     'django_extensions',
     'impersonate',
-    'interval',
     'rest_framework',
     'taggit',
     'taggit_templatetags2',


### PR DESCRIPTION
This doesn't actually change the field type in postgresql
(it's still `interval`). But because this Django package
won't be maintained forever it would be good to switch
to something built into Django (as of Django 1.8).

I left django-pgsql-interval-field in requirements.txt for now
because the initial migration depends on it. Maybe we can get
rid of it by updating the initial migration to use DurationField?
That seems a little crazy so I just left it alone, but maybe
it's fine.