### PR TITLE
Handle AttributeError in SafeOriginPermission

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -28,7 +28,7 @@ class SafeOriginPermission(permissions.BasePermission):
         try:
             return settings.WHITELIST_ORIGIN_IPS and \
                 (remote_addr in settings.WHITELIST_ORIGIN_IPS)
-        except NameError:
+        except AttributeError:
             return False
 
     def _has_safe_referrer(self, referrer):
@@ -38,14 +38,14 @@ class SafeOriginPermission(permissions.BasePermission):
             return referrer and \
                 urlparse(referrer).netloc.endswith(
                     settings.WHITELIST_ORIGIN_URLS)
-        except NameError:
+        except AttributeError:
             return False
 
     def _has_safe_remote_host(self, remote_host):
         try:
             return remote_host and remote_host.endswith(
                 settings.WHITELIST_ORIGIN_URLS)
-        except NameError:
+        except AttributeError:
             return False
 
     def has_permission(self, request, view):

--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -37,9 +37,6 @@ if 'jenkins' in sys.argv:
 if 'test' in sys.argv or 'jenkins' in sys.argv:
     CELERY_ALWAYS_EAGER = True
 
-    WHITELIST_ORIGIN_IPS = (
-    )
-
     WHITELIST_ORIGIN_URLS = (
         '.columbia.edu',
     )


### PR DESCRIPTION
calling settings.WHITELIST_ORIGIN_IPS when it's not defined
raises an AttributeError, not a NameError.