### PR TITLE
Fix active project report export bug - PMT #102627

### DIFF
--- a/dmt/report/mixins.py
+++ b/dmt/report/mixins.py
@@ -15,6 +15,7 @@ class PrevNextWeekMixin(object):
         self.calc_weeks(timezone.now())
 
     def get_params(self):
+        """Update the interval based on request params."""
         date_str = self.request.GET.get('date', '')
         naive = parse_date(date_str)
         if date_str and naive:
@@ -95,6 +96,7 @@ class RangeOffsetMixin(object):
         self.interval_end = aware_end
 
     def get_params(self):
+        """Update the interval based on request params."""
         try:
             self.range_days = int(
                 self.request.GET.get('range', self.range_days))

--- a/dmt/report/views.py
+++ b/dmt/report/views.py
@@ -56,8 +56,9 @@ class ActiveProjectsView(LoggedInMixin, RangeOffsetMixin, TemplateView):
 
 class ActiveProjectsExportView(LoggedInMixin, RangeOffsetMixin, View):
     def get(self, request, *args, **kwargs):
+        self.get_params()
+
         calc = ActiveProjectsCalculator()
-        self.calc_interval()
         data = calc.calc(self.interval_start, self.interval_end)
 
         # Find dates for displaying to the user
@@ -146,7 +147,6 @@ class StaffReportView(LoggedInMixin, RangeOffsetMixin, TemplateView):
 class StaffReportExportView(LoggedInMixin, RangeOffsetMixin, View):
     def get(self, request, *args, **kwargs):
         self.get_params()
-        self.calc_interval()
         calc = StaffReportCalculator(['designers', 'programmers', 'video',
                                       'educationaltechnologists',
                                       'management'])


### PR DESCRIPTION
The active project report exports were ignoring the 'offset' param.