### PR TITLE
Disable linkify in code blocks - PMT #102245

### DIFF
--- a/dmt/main/templatetags/dmttags.py
+++ b/dmt/main/templatetags/dmttags.py
@@ -35,6 +35,7 @@ def interval_to_hours(duration):
 def linkify(value):
     return bleach.linkify(value,
                           skip_pre=True,
+                          skip_code=True,
                           parse_email=False,
                           tokenizer=HTMLTokenizer)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ django-emoji==2.0.0
 django-behave==0.1.5
 django-oauth2-provider==0.2.6.1
 django-extra-views==0.7.1
-bleach==1.4.2
+bleach==1.4.3.ccnmtl
 html5lib==0.999999
 html2text==2015.6.21
 freezegun==0.3.5


### PR DESCRIPTION
Bleach was set up to skip `<pre>` blocks when linkifying html,
but not `<code>` blocks. Making this change fixes PMT #102245.

Unfortunately, I've had to package our own version of bleach..
I'm waiting for feedback on this PR: https://github.com/jsocol/bleach/pull/162