### PR TITLE
Fix ipython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,13 @@ BeautifulSoup==3.2.1
 lxml==3.4.4
 fuzzywuzzy==0.6.0
 sure==1.2.12
+traitlets==4.0.0  # ipython
+ipython_genutils==0.1.0  # ipython
+decorator==4.0.2  # ipython
+pexpect==3.3  # ipython
+pickleshare==0.5  # ipython
+simplegeneric==0.8.1  # ipython
+path.py==8.1.1  # ipython
 ipython==4.0.0
 ipdb==0.8.1
 isodate==0.5.4


### PR DESCRIPTION
IPython now seems to have a lot more requirements.
With version 4.0.0, running `./manage.py shell` just
put me in a normal shell. Then I tried to do
`import IPython`, which showed me the errors for all
the missing packages that it needs.