### PR TITLE
only ever access Notify.user, never .username

### DIFF
--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -219,7 +219,7 @@
       <dd>
           <ul>
               {% for notify in notified_users %}
-              {% with userprofile=notify.username %}
+              {% with userprofile=notify.user.userprofile %}
               <li>
                   <a href="{% url 'user_detail' userprofile.username %}"
                      >{{userprofile.fullname}}</a>


### PR DESCRIPTION
After this, it'll be safe to remove `.username`