### PR TITLE
just remove NotifyProject altogether

### DIFF
--- a/dmt/main/migrations/0031_auto_20151001_1113.py
+++ b/dmt/main/migrations/0031_auto_20151001_1113.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0030_remove_notifyproject_username'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='notifyproject',
+            name='pid',
+        ),
+        migrations.RemoveField(
+            model_name='notifyproject',
+            name='user',
+        ),
+        migrations.DeleteModel(
+            name='NotifyProject',
+        ),
+    ]

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -1131,8 +1131,8 @@ class Item(models.Model):
         self.add_cc(self.assigned_to)
 
     def add_project_notification(self):
-        for n in NotifyProject.objects.filter(pid=self.milestone.project):
-            self.add_cc(n.user.userprofile)
+        for u in self.milestone.project.managers():
+            self.add_cc(u)
 
     def add_cc(self, user):
         if user.status == "inactive":
@@ -1449,14 +1449,6 @@ class Events(models.Model):
         if (s == 'open'):
             s = 'dmt-' + s
         return s
-
-
-class NotifyProject(models.Model):
-    pid = models.ForeignKey(Project, db_column='pid')
-    user = models.ForeignKey(User, null=True)
-
-    class Meta:
-        db_table = u'notify_project'
 
 
 class InGroup(models.Model):


### PR DESCRIPTION
The DMT has actually never had a UI for making new ones, so it's only
supporting a legacy feature on old projects that ought to have a
different overall UI anyway.