### PR TITLE
Add search filtering for 'my items' table - PMT #100751

### DIFF
--- a/dmt/templates/main/index.html
+++ b/dmt/templates/main/index.html
@@ -335,11 +335,10 @@ $(document).ready(function() {
             dom: 'C<"clear">lfrtip',
             colVis: {
                 iOverlayFade: 0,
-            }
+            },
+            searching: true
         });
-        table
-            .order([1, 'desc'], [3, 'asc'])
-            .draw();
+        table.order([1, 'desc'], [3, 'asc']).draw();
     {% endif %}
     {% endwith %}
     $("table#owned-items").tablesorter({sortList: [[1,0], [3,1]]}); 

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -592,8 +592,12 @@ span.attachment-action-text {
 .search-wrapper input:focus:-ms-input-placeholder { color:transparent; } /* Internet Explorer 10+ */
 
 .search-box {
-    height: 26px;
     width: 300px; /* Responsive definition required */
+}
+
+.search-box,
+.dataTables_wrapper input[type="search"] {
+    height: 26px;
     margin-top: 6px;
     padding: 3px 25px 3px 7px;
     border: 1px solid #999;
@@ -702,11 +706,14 @@ nav .container {
 #user-items div.due { background: #f93; }
 #user-items div.late { background: #f00; }
 #user-items div.overdue { background: #000; }
-.dashboard div.ColVis { margin-top: -70px; }
+.dashboard div.ColVis {
+    margin-left: 20px;
+    margin-top: 3px;
+}
 
 .progressbar-set {
     height: 25px;
-    margin: 60px 0 0 0;
+    margin-bottom: 5px;
     padding: 0;
     border: 0;
 }
@@ -869,8 +876,8 @@ div.ColVis_collectionBackground {
 
 .project-tabs,
 .object-tabs {
-    margin-top: 20px;
-    margin-bottom: 20px;
+    margin-top: 10px;
+    margin-bottom: 10px;
     border: 0;
     border-bottom: 5px solid #e2ebf5;
 }
@@ -1345,7 +1352,10 @@ button.pmt-report-submit { margin-top: 25px; }
 
 @media (max-width: 767px) {
     #outer-container { padding-top: 80px; }
-    .ColVis { display: none; }
+    .dataTables_filter,
+    .ColVis {
+        display: none;
+    }
     .theme-brand {
         height: 40px;
         width: 80px;


### PR DESCRIPTION
This adds a search box for the dashboard items in PMT next
to the show/hide columns dropdown.

In order for this to display correctly I needed to remove the
negative-margin hack on the show/hide columns dropdown, and now
the "weekly hours logged" graph is about this button and the search
input. I've also reduced some of the margins to make it look good.

Let me know if you don't like any of these changes, @zmustapha,
these are just some ideas. I really just want to be able to limit
the main "My Items" table by project, and this search box provided
by DataTables seems to work well.

![2015-10-21-144222_726x319_scrot](https://cloud.githubusercontent.com/assets/59292/10646700/9eda2258-7802-11e5-917f-5bc57e7ff8aa.png)
