### PR TITLE
DST fix for reports.mixins.RangeOffsetMixin

### DIFF
--- a/dmt/report/mixins.py
+++ b/dmt/report/mixins.py
@@ -77,13 +77,19 @@ class RangeOffsetMixin(object):
     # this range_days.
     range_days = 31
     offset_days = 0
+    _today = None
+
+    def today(self):
+        if not self._today:
+            self._today = date.today()
+        return self._today
 
     def calc_interval(self):
         # Calculate from the beginning of the first day in the range
         # to the end of the last day.
-        naive_start = datetime.combine(date.today(), datetime.min.time()) - \
+        naive_start = datetime.combine(self.today(), datetime.min.time()) - \
             timedelta(days=(self.range_days + self.offset_days))
-        naive_end = datetime.combine(date.today(), datetime.max.time()) - \
+        naive_end = datetime.combine(self.today(), datetime.max.time()) - \
             timedelta(days=(self.offset_days))
 
         # Convert to TZ-aware, based on the current timezone.

--- a/dmt/report/tests/test_mixins.py
+++ b/dmt/report/tests/test_mixins.py
@@ -1,5 +1,5 @@
 import pytz
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from django.conf import settings
 from django.test import TestCase
 from django.utils.dateparse import parse_datetime
@@ -39,11 +39,13 @@ class RangeOffsetMixinTests(TestCase):
         self.mixin = RangeOffsetMixin()
 
     def test_calc_interval(self):
+        today = parse_datetime('2014-10-27 00:00:00')
+        self.mixin._today = today
         self.mixin.calc_interval()
-        naive_today = datetime.combine(date.today(), datetime.min.time())
+        naive_today = datetime.combine(today, datetime.min.time())
         aware_today = pytz.timezone(settings.TIME_ZONE).localize(
             naive_today, is_dst=None)
-        naive_end_of_today = datetime.combine(date.today(),
+        naive_end_of_today = datetime.combine(today,
                                               datetime.max.time())
         aware_end_of_today = pytz.timezone(settings.TIME_ZONE).localize(
             naive_end_of_today, is_dst=None)


### PR DESCRIPTION
the calc_interval() method doesn't return exactly what is expected when it straddles
a DST change. That's fine, really, but the tests break when that's the case.

To fix it, I made the tests use a set date that doesn't have that problem and
extended RangeOffsetMixin so the  value could be explicitly set (this
makes it easier to test with arbitrary dates in case we want to test the DST
behavior differently later).