### PR TITLE
:arrow_up: billiard 3.3.0.21. PMT #103590

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,8 +53,8 @@ amqp==1.4.7
 amqplib==1.0.2
 kombu==3.0.29
 librabbitmq==1.6.1
-billiard==3.3.0.20
 celery==3.1.19
+billiard==3.3.0.21
 enum34==1.0.4
 parse-type==0.3.4
 parse==1.6.6


### PR DESCRIPTION
(note that the tests will fail because of an unrelated DST bug until that PR has been merged (or significant time passes since the DST switchover)