### PR TITLE
django-oauth2-provider -> django-oauth-toolkit - PMT #103802

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -51,8 +51,7 @@ INSTALLED_APPS += [  # noqa
     'dmt.api',
     'bdd_tests',
     'django_behave',
-    'provider',
-    'provider.oauth2',
+    'oauth2_provider',
 ]
 
 DEBUG_TOOLBAR_CONFIG = {
@@ -75,10 +74,4 @@ REST_FRAMEWORK = {
 
 MESSAGE_TAGS = {
     messages.ERROR: 'danger'
-}
-
-PROVIDER_APPLICATION_MODEL = 'provider.Application'
-
-MIGRATION_MODULES = {
-    'provider': 'dmt.migrations.provider',
 }

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -54,7 +54,7 @@ urlpatterns = patterns(
     url(r'^add_trackers/$', AddTrackersView.as_view(), name='add_trackers'),
     (r'^api/1.0/', include('dmt.api.urls')),
     (r'^drf/', include('dmt.api.urls')),
-    url(r'^oauth2/', include('provider.oauth2.urls', namespace='oauth2')),
+    url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2')),
     (r'^search/$', SearchView.as_view()),
     (r'^client/$', ClientListView.as_view()),
     url(r'^client/(?P<pk>\d+)/$', ClientDetailView.as_view(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,6 +97,9 @@ django-bootstrap3==6.2.2
 django-emoji==2.0.0
 django-behave==0.1.5
 django-oauth2-provider==0.2.6.1
+django-braces==1.8.1
+oauthlib==1.0.3
+django-oauth-toolkit==0.9.0
 django-extra-views==0.7.1
 bleach==1.4.3.ccnmtl
 html5lib==0.999999


### PR DESCRIPTION
This is the first step of the conversion. I'm leaving in the
django-oauth2-provider package while the migration is still
around.