### PR TITLE
Fix reminder url to include domain name

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -243,10 +243,11 @@ class UserProfile(models.Model):
         body = (
             'Reminder: This PMT item is due in {}:\n'.format(
                 simpleduration_string(reminder.reminder_time)) +
-            '{}'.format(reminder.item.get_absolute_url()))
+            'https://pmt.ccnmtl.columbia.edu{}'.format(
+                reminder.item.get_absolute_url()))
 
         send_mail(
-            'PMT Reminder: {}'.format(reminder.item.title),
+            '[PMT Reminder] {}'.format(reminder.item.title),
             body,
             settings.SERVER_EMAIL,
             [self.email],

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -113,12 +113,13 @@ class UserModelTest(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
             mail.outbox[0].subject,
-            'PMT Reminder: {}'.format(r.item.title))
+            '[PMT Reminder] {}'.format(r.item.title))
 
         expected_body = (
             'Reminder: This PMT item is due in {}:\n'.format(
                 simpleduration_string(r.reminder_time)) +
-            '{}'.format(r.item.get_absolute_url()))
+            'https://pmt.ccnmtl.columbia.edu{}'.format(
+                r.item.get_absolute_url()))
 
         self.assertEqual(mail.outbox[0].body, expected_body)
 


### PR DESCRIPTION
The item path needs the domain name to make it usable. I'm
hardcoding this just like we're doing for the Item update
email.