### PR TITLE
Update ravenjs to 1.2.0

### DIFF
--- a/dmt/templates/base.html
+++ b/dmt/templates/base.html
@@ -229,7 +229,7 @@
   </div>
 </div>
 
-<script src="//cdn.ravenjs.com/1.1.18/jquery,native,require/raven.min.js"></script>
+<script src="https://cdn.ravenjs.com/1.2.0/backbone,jquery,native,require/raven.min.js"></script>
 <script>
 Raven.config('https://416166385bf0416f8156c63fd3aebb95@sentry.ccnmtl.columbia.edu/2', {
     whitelistUrls: [/pmt\.ccnmtl\.columbia\.edu/]


### PR DESCRIPTION
The newest version - 1.3.0 - requires Sentry 7.7.0+, while
we're using version 7.4.3.

https://github.com/getsentry/raven-js/blob/master/CHANGELOG.md

I've also added the backbone ravenjs plugin that hooks into backbone
events.