### PR TITLE
link status updates to project page

### DIFF
--- a/dmt/main/feeds.py
+++ b/dmt/main/feeds.py
@@ -47,6 +47,10 @@ class StatusUpdateFeed(Feed):
             item.user.fullname,
             item.added.date())
 
+    def item_link(self, item):
+        return (settings.BASE_URL + item.project.get_absolute_url() +
+                "#status-" + str(item.id))
+
 
 class ProjectFeed(Feed):
     """Create a feed of the active items, per project (id)"""

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -1233,6 +1233,7 @@ class TestFeeds(TestCase):
         r = self.c.get("/feeds/status/")
         self.assertFalse("dmt.ccnmtl.columbia.edu" in r.content)
         self.assertTrue("https://newbase.com" in r.content)
+        self.assertTrue("<link>https://newbase.com/project" in r.content)
 
         NodeFactory()
         r = self.c.get("/feeds/forum/rss/")

--- a/dmt/templates/main/project_detail.html
+++ b/dmt/templates/main/project_detail.html
@@ -378,7 +378,7 @@
   
   <div class="tab-pane fade" id="updates">
     {% for n in object.recent_status_updates %}
-    <div class="status-update">
+    <div class="status-update" id="status-update-{{n.id}}">
       <div class="status-update-byline">
         <a href="{{n.user.get_absolute_url}}">{{n.user.fullname}}</a>
         &#8226;


### PR DESCRIPTION
continuing on PMT #104015

instead of linking to the edit form for a status update, the feed now
links to an appropriate id for the status update on the project page.

note that we still don't have js rigged up to switch to the updates tab
and highlight the linked item yet, but it's better than nothing.