### PR TITLE
unify Makefile and package.json functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,31 @@
 {
-  "name": "dmt",
-  "version": "0.1.0",
-  "description": "Project management tool",
-  "license": "GPL-2.0+",
-  "scripts": {
-    "test": "karma start"
-  },
-  "devDependencies": {
-    "casperjs": "~1.1.0-beta3",
-    "karma": "~0.13.15",
-    "karma-junit-reporter": "~0.3.8",
-    "karma-html2js-preprocessor": "~0.1.0",
-    "karma-phantomjs-launcher": "~0.2.1",
-    "qunitjs": "~1.17.1",
-    "karma-qunit": "~0.1.8",
-    "requirejs": "~2.1.21",
-    "karma-requirejs": "~0.2.2",
-    "karma-sinon": "~1.0.4",
-    "phantomjs": "~1.9.18",
-    "sinon": "~1.17.2",
-    "sinon-qunit": "~2.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/ccnmtl/dmt.git"
-  },
-  "readmeFilename": "README.markdown"
+    "name": "dmt",
+    "version": "0.1.0",
+    "description": "Project management tool",
+    "license": "GPL-2.0+",
+    "scripts": {
+        "test": "karma start"
+    },
+    "devDependencies": {
+        "casperjs": "~1.1.0-beta3",
+        "jscs": "~2.6.0",
+        "jshint": "~2.9.1",
+        "karma": "~0.13.15",
+        "karma-html2js-preprocessor": "~0.1.0",
+        "karma-junit-reporter": "~0.3.8",
+        "karma-phantomjs-launcher": "~0.2.1",
+        "karma-qunit": "~0.1.8",
+        "karma-requirejs": "~0.2.2",
+        "karma-sinon": "~1.0.4",
+        "phantomjs": "~1.9.18",
+        "qunitjs": "~1.17.1",
+        "requirejs": "~2.1.21",
+        "sinon": "~1.17.2",
+        "sinon-qunit": "~2.0.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/ccnmtl/dmt.git"
+    },
+    "readmeFilename": "README.markdown"
 }

--- a/package.json
+++ b/package.json
@@ -1,31 +1,31 @@
 {
-    "name": "dmt",
-    "version": "0.1.0",
-    "description": "Project management tool",
-    "license": "GPL-2.0+",
-    "scripts": {
-        "test": "karma start"
-    },
-    "devDependencies": {
-        "casperjs": "~1.1.0-beta3",
-        "jscs": "~2.6.0",
-        "jshint": "~2.9.1",
-        "karma": "~0.13.15",
-        "karma-html2js-preprocessor": "~0.1.0",
-        "karma-junit-reporter": "~0.3.8",
-        "karma-phantomjs-launcher": "~0.2.1",
-        "karma-qunit": "~0.1.8",
-        "karma-requirejs": "~0.2.2",
-        "karma-sinon": "~1.0.4",
-        "phantomjs": "~1.9.18",
-        "qunitjs": "~1.17.1",
-        "requirejs": "~2.1.21",
-        "sinon": "~1.17.2",
-        "sinon-qunit": "~2.0.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/ccnmtl/dmt.git"
-    },
-    "readmeFilename": "README.markdown"
+  "name": "dmt",
+  "version": "0.1.0",
+  "description": "Project management tool",
+  "license": "GPL-2.0+",
+  "scripts": {
+    "test": "karma start"
+  },
+  "devDependencies": {
+    "casperjs": "~1.1.0-beta3",
+    "jscs": "~2.6.0",
+    "jshint": "~2.9.1",
+    "karma": "~0.13.15",
+    "karma-html2js-preprocessor": "~0.1.0",
+    "karma-junit-reporter": "~0.3.8",
+    "karma-phantomjs-launcher": "~0.2.1",
+    "karma-qunit": "~0.1.8",
+    "karma-requirejs": "~0.2.2",
+    "karma-sinon": "~1.0.4",
+    "phantomjs": "~1.9.18",
+    "qunitjs": "~1.17.1",
+    "requirejs": "~2.1.21",
+    "sinon": "~1.17.2",
+    "sinon-qunit": "~2.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ccnmtl/dmt.git"
+  },
+  "readmeFilename": "README.markdown"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "casperjs": "~1.1.0-beta3",
     "jscs": "~2.6.0",
-    "jshint": "~2.9.1",
+    "jshint": "~2.9.1-rc1",
     "karma": "~0.13.15",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-junit-reporter": "~0.3.8",


### PR DESCRIPTION
Standardizing on using package.json to specify the JS libraries to be
installed so Makefile targets can just install everything with one 'npm
install' instead of scattering stuff around.

I also refactored the build dependencies a bit and added a sentinal
setup so more of this should be automatic (just update package.json and
everything else should happen automatically when needed).

The other thing worth noting is that instead of 'make js' you now would
do 'make media/main-built.js'. That's not as nice to type, but it's a
real file as a target so make can be smarter about whether or not to
rebuild it, which will be better for further deployment automation.