### PR TITLE
Fix UnicodeEncodeError when unicode elements are in comment text

### DIFF
--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -813,6 +813,15 @@ class TestItemWorkflow(TestCase):
         r = self.c.get(i.get_absolute_url())
         self.assertTrue("this is a comment" in r.content)
 
+    def test_add_comment_unicode(self):
+        i = ItemFactory()
+        r = self.c.post(
+            i.get_absolute_url() + "comment/",
+            dict(comment=u'Here is a bullet point: \u2022'))
+        self.assertEqual(r.status_code, 302)
+        r = self.c.get(i.get_absolute_url())
+        self.assertTrue('Here is a bullet point:' in r.content)
+
     def test_add_comment_ccs_user(self):
         """ PMT #103873
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
 Django==1.8.8
-CommonMark==0.6.1
+future==0.15.2
+CommonMark==0.6.2.ccnmtl
 django-markwhat==1.5.ccnmtl
 uuid==1.30
 psycopg2==2.6.1


### PR DESCRIPTION
CommonMark-py was converting objects to strings with `str()`, which
is unicode-compatible on python 3 but not python 2. Using a module
from python-future, this new version of commonmark fixes this sentry
error:

https://sentry.ccnmtl.columbia.edu/sentry-internal/dmt/group/954/