### PR TITLE
Use TextField for milestone name

### DIFF
--- a/dmt/main/migrations/0044_auto_20160120_1454.py
+++ b/dmt/main/migrations/0044_auto_20160120_1454.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0043_remove_statusupdate_user'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='milestone',
+            name='name',
+            field=models.TextField(),
+        ),
+    ]

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -834,7 +834,7 @@ class Document(models.Model):
 
 class Milestone(models.Model):
     mid = models.AutoField(primary_key=True)
-    name = models.CharField(max_length=255)
+    name = models.TextField()
     target_date = models.DateField()
     project = models.ForeignKey(Project, db_column='pid')
     status = models.CharField(max_length=8, default='OPEN')


### PR DESCRIPTION
This addresses the "value too long" error reported here:
https://sentry.ccnmtl.columbia.edu/sentry-internal/dmt/group/964/