### PR TITLE
Duration formatting cleanup - PMT #104842

### DIFF
--- a/dmt/main/templatetags/dmttags.py
+++ b/dmt/main/templatetags/dmttags.py
@@ -31,6 +31,11 @@ def interval_to_hours(duration):
     return utils.interval_to_hours(duration)
 
 
+@register.filter
+def simpleduration(duration):
+    return utils.simpleduration_string(duration)
+
+
 @register.filter(is_safe=True)
 def linkify(value):
     return bleach.linkify(value,

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -934,7 +934,7 @@ class TestItemWorkflow(TestCase):
         self.assertTrue("this is a comment" in r.content)
         self.assertTrue("RESOLVED" in r.content)
         self.assertTrue("FIXED" in r.content)
-        self.assertTrue("2:30:00" in r.content)
+        self.assertTrue("2h 30m" in r.content)
 
     def test_resolve_self_assigned(self):
         i = ItemFactory(owner=self.u.userprofile,

--- a/dmt/templates/main/item_detail.html
+++ b/dmt/templates/main/item_detail.html
@@ -156,7 +156,9 @@
 
       {% if object.estimated_time %}
       <dt>Estimated time</dt>
-      <dd>{{object.estimated_time}}</dd>
+      {% with objtime=object.estimated_time|interval_to_hours %}
+      <dd>{{objtime}} hour{{objtime|pluralize}}</dd>
+      {% endwith %}
       {% endif %}
 
       {% if object.url %}
@@ -249,8 +251,12 @@
       <dd>
       {% for at in object.actualtime_set.all %}
       <ul class="time-logged">
-      <li>{{at.actual_time}} <a href="{{at.user.userprofile.get_absolute_url}}">{{at.user.userprofile.fullname}}</a>
-      {{at.completed}}</li>
+          <li>
+              {{at.actual_time|simpleduration}}
+              <a href="{{at.user.userprofile.get_absolute_url}}"
+                 >{{at.user.userprofile.fullname}}</a>
+              {{at.completed}}
+          </li>
       </ul>
       {% endfor %}
       </dd>

--- a/dmt/templates/report/user_weekly.html
+++ b/dmt/templates/report/user_weekly.html
@@ -38,7 +38,9 @@ User Weekly Report: {{u.fullname}} ({{week_start}} to {{week_end}})
 		{% for project in active_projects %}
 		<tr>
 			<td><a href="{{project.get_absolute_url}}">{{project.name}}</a></td>
-			<td>{{project.time|interval_to_hours}} hours</td>
+            {% with projtime=project.time|interval_to_hours %}
+			<td>{{projtime}} hour{{projtime|pluralize}}</td>
+            {% endwith %}
 		</tr>
 		{% endfor %}
 	</tbody>
@@ -59,7 +61,9 @@ User Weekly Report: {{u.fullname}} ({{week_start}} to {{week_end}})
 	<tbody>
 		{% for t in individual_times %}
 		<tr>
-			<td>{{t.actual_time|interval_to_hours}} hours</td>
+            {% with ttime=t.actual_time|interval_to_hours %}
+			<td>{{ttime}} hour{{ttime|pluralize}}</td>
+            {% endwith %}
 			<td><a href="{{t.item.get_absolute_url}}">{{t.item.title}}</a></td>
 			<td>{{t.completed}}</td>
 			<td><a href="{{t.item.milestone.project.get_absolute_url}}">{{t.item.milestone.project}}</a></td>


### PR DESCRIPTION
I've removed the seconds field when displaying durations, since it's not
relevant.