### PR TITLE
Add a calendar icon to target date widget

### DIFF
--- a/dmt/templates/main/project_add_action_item_form.html
+++ b/dmt/templates/main/project_add_action_item_form.html
@@ -88,9 +88,13 @@
 
                       <div class="form-group pull-right form-group-col-2">
                           <label for="actionitem_target_date">Target Date</label>
-                          <input type="text" name="target_date"
-                                 id="actionitem_target_date"
-                                 class="form-control" />
+                          <div class="left-inner-placeholder">
+                              <span class="glyphicon glyphicon-calendar text-muted"
+                                    aria-hidden="true"></span>
+                              <input type="text" name="target_date"
+                                     id="actionitem_target_date"
+                                     class="form-control" />
+                          </div>
                       </div>
                     </div>
 

--- a/dmt/templates/main/project_add_bug_form.html
+++ b/dmt/templates/main/project_add_bug_form.html
@@ -69,9 +69,13 @@
   
                       <div class="form-group pull-right form-group-col-2">
                           <label for="bug_target_date">Target Date</label>
-                          <input type="text" name="target_date"
-                                 id="bug_target_date"
-                                 class="form-control" />
+                          <div class="left-inner-placeholder">
+                              <span class="glyphicon glyphicon-calendar text-muted"
+                                    aria-hidden="true"></span>
+                              <input type="text" name="target_date"
+                                     id="bug_target_date"
+                                     class="form-control" />
+                          </div>
                       </div>
                     </div>
 

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1486,3 +1486,17 @@ button.pmt-report-submit { margin-top: 25px; }
 select#project-personnel-input {
     min-width: 200px;
 }
+
+.left-inner-placeholder {
+    position: relative;
+}
+
+.left-inner-placeholder input {
+    padding-left: 30px;
+}
+
+.left-inner-placeholder span.glyphicon {
+    position: absolute;
+    padding: 10px 12px;
+    pointer-events: none;
+}


### PR DESCRIPTION
To let users know it's not a normal text field:

![2016-01-25-162757_305x91_scrot](https://cloud.githubusercontent.com/assets/59292/12565077/cb4b4ef6-c380-11e5-9d32-c4a4ba74f254.png)
