### PR TITLE
Pick up the correct client IP address

### DIFF
--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -49,11 +49,13 @@ class SafeOriginPermission(permissions.BasePermission):
             return False
 
     def has_permission(self, request, view):
-        remote_addr = request.META.get('HTTP_X_REAL_IP')
+        real_ip = request.META.get('HTTP_X_REAL_IP')
+        remote_addr = request.META.get('REMOTE_ADDR')
         remote_host = request.META.get('REMOTE_HOST')
         referrer = request.META.get('HTTP_REFERER')
 
         checks = [
+            self._has_safe_remote_addr(real_ip),
             self._has_safe_remote_addr(remote_addr),
             self._has_safe_remote_host(remote_host),
             self._has_safe_referrer(referrer),

--- a/dmt/api/auth.py
+++ b/dmt/api/auth.py
@@ -49,7 +49,7 @@ class SafeOriginPermission(permissions.BasePermission):
             return False
 
     def has_permission(self, request, view):
-        remote_addr = request.META.get('REMOTE_ADDR')
+        remote_addr = request.META.get('HTTP_X_REAL_IP')
         remote_host = request.META.get('REMOTE_HOST')
         referrer = request.META.get('HTTP_REFERER')
 


### PR DESCRIPTION
Use the custom HTTP_X_REAL_IP header instead of REMOTE_ADDR to pickup the client address.
With the new linode/nginx setup, the REMOTE_ADDR was coming through as the proxy server.