### PR TITLE
Remove interval from INSTALLED_APPS

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -39,7 +39,6 @@ djcelery.setup_loader()
 INSTALLED_APPS += [  # noqa
     'django.contrib.messages',
     'django_extensions',
-    'interval',
     'rest_framework',
     'taggit',
     'taggit_templatetags2',


### PR DESCRIPTION
eventually need to figure out how to remove pgsql-interval-field from
requirements.txt as well.