### PR TITLE
Remove test skips from active project tests

### DIFF
--- a/dmt/report/tests/test_models.py
+++ b/dmt/report/tests/test_models.py
@@ -16,10 +16,6 @@ class ActiveProjectsCalculatorTests(TestCase):
         self.interval_start = now - timedelta(days=365)
         self.interval_end = self.interval_start + timedelta(days=365)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_calc_on_empty_db(self):
         calc = ActiveProjectsCalculator()
         calc.calc(self.interval_start, self.interval_end)

--- a/dmt/report/tests/test_views.py
+++ b/dmt/report/tests/test_views.py
@@ -13,10 +13,6 @@ import unittest
 
 
 class ActiveProjectTests(LoggedInTestMixin, TestCase):
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_active_project_view(self):
         r = self.client.get(reverse('active_projects_report'))
         self.assertEqual(r.status_code, 200)
@@ -29,10 +25,6 @@ class ActiveProjectExportTests(LoggedInTestMixin, TestCase):
         completed = timezone.now() - timedelta(days=35)
         ActualTimeFactory(completed=completed)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_active_project_export_csv_view(self):
         r = self.client.get(
             reverse('active_projects_report_export'), {
@@ -51,10 +43,6 @@ class ActiveProjectExportTests(LoggedInTestMixin, TestCase):
         self.assertEqual(r_offset.status_code, 200)
         self.assertNotEqual(r.content, r_offset.content)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_active_project_export_excel_view(self):
         r = self.client.get(
             reverse('active_projects_report_export'), {


### PR DESCRIPTION
Because Project.projects_active_between() has been refactored to use
Django's ORM instead of SQL, these tests should run in sqlite.