### PR TITLE
attempt to address freezegun error in jenkins

### DIFF
--- a/dmt/report/tests/test_views.py
+++ b/dmt/report/tests/test_views.py
@@ -18,12 +18,16 @@ class ActiveProjectTests(LoggedInTestMixin, TestCase):
         self.assertEqual(r.status_code, 200)
 
 
-@freeze_time('2016-02-01')
 class ActiveProjectExportTests(LoggedInTestMixin, TestCase):
     def setUp(self):
+        self.freezer = freeze_time("2016-02-01 00:00:00")
+        self.freezer.start()
         super(ActiveProjectExportTests, self).setUp()
         completed = timezone.now() - timedelta(days=35)
         ActualTimeFactory(completed=completed)
+
+    def tearDown(self):
+        self.freezer.stop()
 
     def test_active_project_export_csv_view(self):
         r = self.client.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ django-extra-views==0.7.1
 bleach==1.4.3.ccnmtl
 html5lib==0.9999999
 html2text==2015.6.21
-freezegun==0.3.5
+freezegun==0.3.6
 gunicorn==19.3.0
 django-storages-redux==1.3.2
 django-cacheds3storage==0.1.1


### PR DESCRIPTION
> "/home/pusher/.jenkins/jobs/dmt/workspace/ve/local/lib/python2.7/site-packages/freezegun/api.py",
> line 193, in _time_to_freeze
>     return cls.times_to_freeze[-1]()
>     IndexError: list index out of range

I wasn't able to reproduce the problem at first, but after changing the
way I'm using freezegun in this test (manually starting and stopping it
in setUp and tearDown), I triggered the problem locally. Upgrading to
freezegun 0.3.6 fixed this problem for me, we'll see if it works on
jenkins.