### PR TITLE
Fix daterange display when window < 1024px wide

### DIFF
--- a/dmt/templates/main/daterange_form.html
+++ b/dmt/templates/main/daterange_form.html
@@ -12,9 +12,9 @@
                    value="{{interval_end|format_ymd}}">
         </div>
     </div>
-    <div class="form-group col-sm-2">
+    <div class="form-group col-md-2">
         <button type="submit"
                 class="btn btn-default pmt-report-submit"
-                >Submit</button>
+        >Submit</button>
     </div>
 </form>

--- a/dmt/templates/report/active_projects.html
+++ b/dmt/templates/report/active_projects.html
@@ -15,20 +15,18 @@
 
 {% include 'main/daterange_form.html' %}
 
-<div class="row">
-    <div class="col-md-3">
-        <div class="control-group">
-            Total hours reported:
-            <strong>{{total_hours}}</strong>
-        </div>
+<div class="col-md-3">
+    <div class="control-group">
+        Total hours reported:
+        <strong>{{total_hours}}</strong>
+    </div>
 
-        <div class="control-group">
-            Export as:
-            <a href="{% url 'active_projects_report_export' %}?format=csv&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
-               >.csv</a>,
-            <a href="{% url 'active_projects_report_export' %}?format=xlsx&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
-               >.xlsx</a>
-        </div>
+    <div class="control-group">
+        Export as:
+        <a href="{% url 'active_projects_report_export' %}?format=csv&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
+        >.csv</a>,
+        <a href="{% url 'active_projects_report_export' %}?format=xlsx&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
+        >.xlsx</a>
     </div>
 </div>
 

--- a/dmt/templates/report/staff_report.html
+++ b/dmt/templates/report/staff_report.html
@@ -20,14 +20,12 @@
 
 {% include 'main/daterange_form.html' %}
 
-<div class="row">
-    <div class="col-md-3">
-        Export as:
-        <a href="{% url 'staff_report_export' %}?format=csv&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
-           >.csv</a>,
-        <a href="{% url 'staff_report_export' %}?format=xlsx&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
-           >.xlsx</a>
-    </div>
+<div class="col-md-3">
+    Export as:
+    <a href="{% url 'staff_report_export' %}?format=csv&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
+    >.csv</a>,
+    <a href="{% url 'staff_report_export' %}?format=xlsx&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
+    >.xlsx</a>
 </div>
 
 <table class="table table-striped table-condensed tablesorter tablesorter-default" id="staff-report">


### PR DESCRIPTION
When looking at the staff report in a window <1024px wide, the "Export
as" row was interfering with the daterange form's "Submit" button - it
was still visible, but most of it was clickable. I've changed around
a bootstrap grid setting in the daterange form and taken the export area
out of a `class="row"`, and the problem is fixed.