### PR TITLE
Populate all ActualTime uuids in manage command, fix typo

### DIFF
--- a/dmt/main/management/commands/populate_actualtime_uuids.py
+++ b/dmt/main/management/commands/populate_actualtime_uuids.py
@@ -6,6 +6,6 @@ from dmt.main.models import ActualTime
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         """Assign uuids to ActualTimes that don't have one."""
-        for time in ActualTime.objects.filter(uuid=None):
-            time.uuid == uuid.uuid4()
+        for time in ActualTime.objects.all():
+            time.uuid = uuid.uuid4()
             time.save()


### PR DESCRIPTION
This lets us run this command again to re-populate the uuids. There
was a really dumb typo in this code: `==` instead of `=`!
This should address the issue where the entire table has the same
uuid.
