### PR TITLE
Fix user links in project report - PMT #105646

### DIFF
--- a/dmt/templates/main/project_detail_report.html
+++ b/dmt/templates/main/project_detail_report.html
@@ -23,7 +23,7 @@
         {% for u in users_active_in_range %}
         <tr>
             <td>
-                <a href="{% url 'user_detail' u.username %}"
+                <a href="{% url 'user_detail' u.userprofile.username %}"
                    >{{ u.userprofile.fullname }}</a>
             </td>
             <td>{{ u.hours_logged|interval_to_hours }}</td>


### PR DESCRIPTION
The user links on the project reports was giving a 404 for users whose
username isn't their uni. For newer users in PMT, the username is the
uni, but users who have been around for a while have a custom username.
I've fixed the template to look at the same attribute as the active
project report template, which doesn't have this problem.