### PR TITLE
re-enable some tests on SQLite

### DIFF
--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.test import TestCase
-from django.conf import settings
 from django.core import mail
 from django.utils import timezone
 import unittest
@@ -292,13 +291,6 @@ class ItemTest(TestCase):
         actualtime = ActualTime.objects.first()
         self.assertEqual(actualtime.actual_time, timedelta(0, 3600))
 
-    # SQLite can't handle aggregate functions on datetime fields
-    # https://docs.djangoproject.com/en/dev/ref/models/querysets/
-    # #aggregation-functions
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_get_resolve_zero(self):
         i = ItemFactory()
         u = UserProfileFactory()
@@ -307,10 +299,6 @@ class ItemTest(TestCase):
         resolve_time = i.get_resolve_time()
         self.assertEqual(resolve_time, timedelta(0, 0))
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_get_resolve_time_1h(self):
         i = ItemFactory()
         u = UserProfileFactory()
@@ -328,10 +316,6 @@ class ItemTest(TestCase):
             Notify.objects.filter(
                 item=i.iid, user=assignee.user).count(), 1)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_get_resolve_time_multiple_times(self):
         i = ItemFactory()
 

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -1530,10 +1530,6 @@ class TestAddTrackersView(LoggedInTestMixin, TestCase):
         })
         self.assertEqual(r.status_code, 302)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_add_trackers_post_multiple(self):
         r = self.client.post(reverse('add_trackers'), self.valid_post_data)
 
@@ -1557,10 +1553,6 @@ class TestAddTrackersView(LoggedInTestMixin, TestCase):
                 items[i].get_resolve_time(),
                 Duration(self.valid_post_data['form-%d-time' % i]).timedelta())
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_add_trackers_post_single(self):
         params = self.valid_post_data.copy()
         params.update({
@@ -1593,10 +1585,6 @@ class TestAddTrackersView(LoggedInTestMixin, TestCase):
             i.get_resolve_time(),
             Duration(self.valid_post_data['form-0-time']).timedelta())
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_add_trackers_post_tracker_invalid(self):
         params = self.valid_post_data.copy()
         params.update({


### PR DESCRIPTION
Now that we use `DurationField`, a bunch of these can now run on SQLite
and don't have to be Postgres-only.