### PR TITLE
merge tag functionality. PMT #92383

### DIFF
--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -846,6 +846,30 @@ class TestItemTagViews(LoggedInTestMixin, TestCase):
         self.assertTrue("tagone" in r.content)
 
 
+class TestTagViews(LoggedInTestMixin, TestCase):
+    def setUp(self):
+        super(TestTagViews, self).setUp()
+
+    def test_merge_tags_form(self):
+        i = ItemFactory()
+        i.tags.add('testtag', 'testtag2')
+        r = self.client.get(reverse('merge_tag', args=['testtag']))
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue('value="testtag2"' in r.content)
+
+    def test_merge_tags(self):
+        i = ItemFactory()
+        i.tags.add('testtag', 'testtag2')
+        r = self.client.post(
+            reverse('merge_tag', args=['testtag']),
+            dict(tag='testtag2')
+        )
+        self.assertEqual(r.status_code, 302)
+        i.refresh_from_db()
+        self.assertEqual(len(i.tags.names()), 1)
+        self.assertIn(u'testtag2', i.tags.names())
+
+
 class TestItemWorkflow(TestCase):
     def setUp(self):
         self.c = self.client

--- a/dmt/templates/main/merge_tag_form.html
+++ b/dmt/templates/main/merge_tag_form.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <ul class="breadcrumb">
+        <li><a href="/"><span class="glyphicon glyphicon-home"></span></a></li>
+        <li><a href="{% url 'tag_list' %}">Tags</a></li>
+        <li class="active"><a href="{% url 'tag_detail' tag.slug %}">{{tag.name}}</a></li>
+    </ul>
+
+    <form action="." method="post">
+        {% csrf_token %}
+        <fieldset><legend>Merge Tag</legend>
+            <div class="form-group">
+                <label for="select-tag">Merge tag <a href="{% url 'tag_detail' tag.slug %}">{{tag.name}}</a> into:</label>
+                <select name="tag" id="select-tag">
+                    {% for t in all_tags %}
+                        {% if t != tag %}
+                            <option value="{{t.slug}}">{{t.name}}</option>
+                        {% endif %}
+                    {% endfor %}
+                </select>
+            </div>
+            <p>All occurrences of <a href="{% url 'tag_detail' tag.slug %}">{{tag.name}}</a> will be replaced with the selected tag.</p>
+            <input type="submit" class="btn btn-primary" value="Merge" />
+        </fieldset>
+    </form>
+    
+{% endblock %}

--- a/dmt/templates/taggit/tag_detail.html
+++ b/dmt/templates/taggit/tag_detail.html
@@ -9,6 +9,7 @@
 <h1>Tag: {{object.name}}</h1>
 
 <p class="pull-right">
+    <a href="{% url 'merge_tag' object.slug %}" class="btn btn-default">Merge</a>
 <a href="{% url 'delete_tag' object.slug %}" class="btn btn-danger"><span class="glyphicon
 																											glyphicon-trash"></span>
 	Delete</a>

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -29,7 +29,7 @@ from dmt.main.views import (
     DeleteAttachmentView, GroupCreateView,
     DeactivateUserView, ItemMoveProjectView, RemoveUserFromGroupView,
     AddUserToGroupView, MilestoneDeleteView, OwnedItemsView,
-    ItemSetMilestoneView,
+    ItemSetMilestoneView, MergeTagView,
 )
 from dmt.main.feeds import ForumFeed, StatusUpdateFeed, ProjectFeed
 
@@ -167,7 +167,9 @@ urlpatterns = patterns(
     url(r'^user/(?P<pk>\w+)/timeline/$', UserTimeLineView.as_view(),
         name='user_timeline'),
     url(r'^tag/$', TagListView.as_view(), name='tag_list'),
-    (r'^tag/(?P<slug>[^/]+)/$', TagDetailView.as_view()),
+    url(r'^tag/(?P<slug>[^/]+)/$', TagDetailView.as_view(), name='tag_detail'),
+    url(r'^tag/(?P<slug>[^/]+)/merge/$', MergeTagView.as_view(),
+        name='merge_tag'),
     url(r'^tag/(?P<slug>[^/]+)/delete/$', DeleteTagView.as_view(),
         name="delete_tag"),
     url(r'^dashboard/$', DashboardView.as_view(), name='project_dashboard'),


### PR DESCRIPTION
Handy for cleaning up tags. There are a bunch of very similarish tags
that people have put in and that makes tags less useful. Eg, people have
entered 'webservices', 'web-services', and 'web services' tags. Clearly,
those are supposed to be the same thing, but instead they are
separate. This makes it fairly simple to go into whichever are
considered non-canonical and merge them into the canonical tag.