### PR TITLE
parallel tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ compose-migrate:
 media/main-built.js: $(JS_SENTINAL) build.js media/js/src media/js/libs
 	$(REQUIREJS) -o build.js
 
-travis: $(JS_SENTINAL) jenkins jstest integration
+travis: $(JS_SENTINAL) parallel-tests jstest integration

--- a/django.mk
+++ b/django.mk
@@ -27,6 +27,9 @@ $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 test: $(PY_SENTINAL)
 	$(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc
 
+parallel-tests: $(PY_SENTINAL)
+	$(MANAGE) test --parallel
+
 flake8: $(PY_SENTINAL)
 	$(FLAKE8) $(PY_DIRS) --max-complexity=$(MAX_COMPLEXITY)
 


### PR DESCRIPTION
Django 1.9 introduced the ability to run unit tests in parallel.

So I added a 'parallel-tests' target. On my desktop, with 8 cores, it
`make test` is 15 seconds while `make parallel-tests` is 2.5 seconds.

Leaving the existing on in place for now though as django-jenkins
doesn't yet know about parallel tests. So we'll need to either wait for
that or just replace django-jenkins and add our own coverage reporting.