### PR TITLE
handle missing target date on external add item

### DIFF
--- a/dmt/api/tests/test_views.py
+++ b/dmt/api/tests/test_views.py
@@ -437,6 +437,24 @@ class ExternalAddItemTests(APITestCase):
                              HTTP_REFERER=self.remote_host)
         self.assertEqual(r.status_code, 200)
 
+    def test_handles_missing_target_date(self):
+        self.post_data['target_date'] = ''
+        r = self.client.post(reverse('external-add-item'),
+                             self.post_data,
+                             REMOTE_HOST=self.remote_host)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data.get('title'), self.title)
+        self.assertTrue(
+            'Submitted by Item Submitter <submission_email@example.com>' in
+            r.data.get('description')
+        )
+        self.assertEqual(r.data.get('type'), 'action item')
+        self.assertTrue(self.owner.username in r.data.get('owner'))
+        self.assertTrue(self.assignee.username in r.data.get('assigned_to'))
+        self.assertTrue(self.debug_info in r.data.get('description'))
+        self.assertTrue(unicode(self.milestone.pk) in r.data.get('milestone'))
+        self.assertEqual(r.data.get('estimated_time'), '01:00:00')
+
 
 class NotifyTests(APITestCase):
     def setUp(self):

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -97,10 +97,13 @@ class ExternalAddItemView(APIView):
         append_iid = request.data.get('append_iid', '')
         description = get_description(description, debug_info, name, email)
         project = get_object_or_404(Project, pid=pid)
+        milestone = get_milestone(mid, project)
 
         assignee = get_assignee(assignee_username, project)
         owner = get_owner(owner_username, project)
-        milestone = get_milestone(mid, project)
+
+        if target_date == '':
+            target_date = str(milestone.target_date)
 
         item = project.add_item(
             type=item_type,


### PR DESCRIPTION
Addresses:
https://sentry.ccnmtl.columbia.edu/sentry-internal/dmt/group/1040/

If `target_date` is missing or empty, default to the milestone's target
date (same as regular add item).

This fixes the sentry error, but does not there's still the question of
how to handle an invalid target_date. I'm going to leave that as an open
issue for now.