### PR TITLE
remove uuid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 Django==1.9.4
 future==0.15.2
 CommonMark==0.6.2
-uuid==1.30
 psycopg2==2.6.1
 versiontools==1.9.1
 statsd==3.2.1


### PR DESCRIPTION
uuid library comes with python 2.7

don't need to pip install it