### PR TITLE
add tblib for tracebacks on parallel tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -73,6 +73,7 @@ XlsxWriter==0.8.4
 splinter==0.7.3
 shortuuid==0.4.3
 contextlib2==0.5.1
+tblib==1.3.0
 
 djangowind==0.14.3
 django-staticmedia==0.2.2


### PR DESCRIPTION
when running parallel tests, if any fail, tblib is required to actually
see the tracebacks.