### PR TITLE
eliminate remaining pg-only tests. PMT #105903

### DIFF
--- a/dmt/report/tests/test_models.py
+++ b/dmt/report/tests/test_models.py
@@ -1,8 +1,6 @@
 from datetime import timedelta
 from django.test import TestCase
-from django.conf import settings
 from django.utils import timezone
-import unittest
 
 from dmt.report.models import (
     ActiveProjectsCalculator,
@@ -42,10 +40,6 @@ class WeeklySummaryReportCalculatorTests(TestCase):
         self.week_start = now + timedelta(days=-now.weekday())
         self.week_end = self.week_start + timedelta(days=6)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_calc_on_empty_db(self):
         calc = WeeklySummaryReportCalculator(['programmers'])
         calc.calc(self.week_start, self.week_end)

--- a/dmt/report/tests/test_views.py
+++ b/dmt/report/tests/test_views.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 from django.test import TestCase
-from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -9,7 +8,6 @@ from dmt.main.tests.factories import (
     ActualTimeFactory, ItemFactory, MilestoneFactory, UserProfileFactory
 )
 from dmt.main.tests.support.mixins import LoggedInTestMixin
-import unittest
 
 
 class ActiveProjectTests(LoggedInTestMixin, TestCase):
@@ -151,29 +149,17 @@ class InprogressItemsViewTest(LoggedInTestMixin, TestCase):
 
 
 class WeeklySummaryTests(LoggedInTestMixin, TestCase):
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_weekly_summary_view(self):
         r = self.client.get(reverse('weekly_summary_report'))
         self.assertEqual(r.status_code, 200)
 
 
 class WeeklySummaryExportTests(LoggedInTestMixin, TestCase):
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_weekly_summary_export_csv_view(self):
         r = self.client.get(reverse('weekly_summary_report_export') +
                             '?format=csv')
         self.assertEqual(r.status_code, 200)
 
-    @unittest.skipUnless(
-        settings.DATABASES['default']['ENGINE'] ==
-        'django.db.backends.postgresql_psycopg2',
-        "This test requires PostgreSQL")
     def test_weekly_summar_export_excel_view(self):
         r = self.client.get(reverse('weekly_summary_report_export') +
                             '?format=xlsx')


### PR DESCRIPTION
Rewrite query in Project.projects_active_during to not use PG-specific
array syntax. This involves doing a query per group instead of one
single query, since this is only used on report pages, I think we can
get away with that.