### PR TITLE
Display deleted time on confirmation page

### DIFF
--- a/dmt/templates/main/actualtime_confirm_delete.html
+++ b/dmt/templates/main/actualtime_confirm_delete.html
@@ -1,6 +1,11 @@
 {% extends 'base.html' %}
+{% load dmttags %}
 
 {% block content %}
+    <div>
+        <strong>{{ object.actual_time|simpleduration }}</strong>
+        on item: <strong>{{ object.item.title }}</strong>
+    </div>
 
 <form action="." method="post">{% csrf_token %}
 <input class="btn btn-danger" type="submit" value="Yes, delete this time"/>


### PR DESCRIPTION
When deleting a time object, we should display some info about it on the
confirmation page to avoid mistakes.