### PR TITLE
Remove html2text

### DIFF
--- a/dmt/main/migrations/0018_html2text.py
+++ b/dmt/main/migrations/0018_html2text.py
@@ -1,45 +1,5 @@
 # -*- coding: utf-8 -*-
-from HTMLParser import HTMLParseError
 from django.db import migrations
-from django.db.models import Q
-import html2text
-
-
-def populate_comment_src(apps, schema_editor):
-    """
-    Populate the "comment_src" field of comments.
-    """
-    Comment = apps.get_model('main', 'Comment')
-    for comment in Comment.objects.filter(
-            comment_src='', event_id=None).filter(~Q(comment='')):
-        try:
-            comment.comment_src = html2text.html2text(comment.comment)
-        except (ValueError, HTMLParseError):
-            # If html2text raises a ValueError or
-            # HTMLParseError with one of these comments,
-            # it's probably due to an invalid unicode
-            # entity, so just leave the src blank. The
-            # comment will continue to display in PMT
-            # as usual, this just means that if the user
-            # tries to edit the comment, the comment field
-            # will be blank and they will have to copy it
-            # over manually.
-            #
-            # See this github issue:
-            # https://github.com/Alir3z4/html2text/issues/74
-            pass
-        comment.save()
-
-
-def unpopulate_comment_src(apps, schema_editor):
-    """
-    Unpopulate the "comment_src" field of comments.
-    """
-    Comment = apps.get_model('main', 'Comment')
-    for comment in Comment.objects.filter(
-            event_id=None).filter(~Q(comment_src='')):
-        comment.comment_src = ''
-        comment.save()
 
 
 class Migration(migrations.Migration):
@@ -49,6 +9,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(populate_comment_src,
-                             unpopulate_comment_src),
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,6 @@ django-oauth-toolkit==0.9.0
 django-extra-views==0.7.1
 bleach==1.4.3.ccnmtl
 html5lib==0.9999999
-html2text==2015.6.21
 freezegun==0.3.7
 gunicorn==19.3.0
 django-storages-redux==1.3.2


### PR DESCRIPTION
This was required for a one-time data migration that's not needed
anymore.