### PR TITLE
Round weekly progress hours to 2 digits

### DIFF
--- a/dmt/templates/main/index.html
+++ b/dmt/templates/main/index.html
@@ -175,7 +175,7 @@
              role="progressbar"
              aria-valuenow="{{progress.week_percentage}}" aria-valuemin="0"
              aria-valuemax="100" style="width: {{progress.week_percentage}}%; text-align: right;">
-            <span class="progress-hours">{{progress.hours_logged|floatformat}}</span>
+            <span class="progress-hours">{{progress.hours_logged|floatformat:2}}</span>
         </div>
     </div>
   </div><!-- ./progressbar-bar -->


### PR DESCRIPTION
When hours are recorded in 15 minute increments, the weekly progress hours display currently rounds to 1 digit. So, 1.25h becomes 1.3h in the progress indicator. Or, in this case, 3.75h becomes 3.8.

<img width="338" alt="screen shot 2016-05-03 at 12 05 57 pm" src="https://cloud.githubusercontent.com/assets/141369/14989782/6ef35910-1127-11e6-945a-94a4f2ffdd69.png">

This pull request changes the template display to 2 digits, so 1.25h displays as such. Noting that 1.5 will now display with a trailing 0. This is a minor pet peeve. If there's disagreement, I'm fine closing.