### PR TITLE
Hours logged: Hide decimal place when not applicable

### DIFF
--- a/dmt/templates/main/index.html
+++ b/dmt/templates/main/index.html
@@ -175,7 +175,7 @@
              role="progressbar"
              aria-valuenow="{{progress.week_percentage}}" aria-valuemin="0"
              aria-valuemax="100" style="width: {{progress.week_percentage}}%; text-align: right;">
-            <span class="progress-hours">{{progress.hours_logged|floatformat:2}}</span>
+            <span class="progress-hours">{{progress.hours_logged|floatformat:"-2"}}</span>
         </div>
     </div>
   </div><!-- ./progressbar-bar -->


### PR DESCRIPTION
> If the argument passed to floatformat is negative, it will round a
> number to that many decimal places – but only if there’s a decimal
> part to be displayed.