### PR TITLE
add django-crispy-forms

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -49,6 +49,7 @@ INSTALLED_APPS += [  # noqa
     'behave_django',
     'oauth2_provider',
     's3sign',
+    'crispy_forms',
 ]
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,6 +97,7 @@ django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-impersonate==1.0.1
 django-filter==0.13.0
+django-crispy-forms==1.6.0
 djangorestframework==3.3.3
 django-taggit==0.20.0
 django-templatetag-sugar==1.0


### PR DESCRIPTION
one of django-rest-filter's templates expects it and causes compress to
complain:

```
Invalid template
/var/www/dmt/releases/green/dmt/ve/local/lib/python2.7/site-packages/rest_framework/templates/rest_framework/filters/django_filter_crispyforms.html:
'crispy_forms_tags' is not a registered tag library. Must be one of:
...
```