### PR TITLE
Prevent user from changing project on item creation form

### DIFF
--- a/dmt/main/forms.py
+++ b/dmt/main/forms.py
@@ -184,6 +184,7 @@ class ItemCreateForm(ModelForm):
         queryset=User.objects.filter(is_active=True).order_by(
             'last_name').order_by('first_name'))
     project = forms.ModelChoiceField(
+        disabled=True,
         queryset=Project.objects.all())
     estimated_time = SimpleDurationField(
         help_text='Enter time and unit. For example: <code>2h</code>',


### PR DESCRIPTION
Changing the project on the new standalone action item creation
form would require the list of milestone options to updated,
which isn't functionality I plan to implement during this phase.