### PR TITLE
fallback to User for comment

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -1615,7 +1615,10 @@ class Comment(models.Model):
         ordering = ['add_date_time', ]
 
     def user(self):
-        return UserProfile.objects.get(username=self.username)
+        try:
+            return UserProfile.objects.get(username=self.username)
+        except UserProfile.DoesNotExist:
+            return User.objects.get(username=self.username).userprofile
 
     def user_is_owner(self, user):
         """Return True if user is comment owner."""

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -361,6 +361,18 @@ class CommentTest(TestCase):
             self.c.save()
             self.assertTrue(self.c.has_been_edited())
 
+    def test_user_accepts_user_or_userprofile(self):
+        u = UserFactory()
+        self.c.username = u.username
+        self.c.save()
+        self.assertEqual(self.c.user(), u.userprofile)
+
+        c = CommentFactory()
+        up = UserProfileFactory()
+        c.username = up.username
+        c.save()
+        self.assertEqual(c.user(), up)
+
 
 class HistoryItemTest(TestCase):
     def test_status(self):


### PR DESCRIPTION
looking into this PMT #106983, I find this sentry error:
https://sentry.ccnmtl.columbia.edu/sentry-internal/dmt/group/1099/

it appears that recently some change is now setting the username on some
comments to the username of the `User`, not the `UserProfile` as it was
expecting, which in turn means that it now occasionally blows up when it
hits a user with a different username between the two.

I'm going to dig a bit further and see if I can figure out where the
change came in and fix it there, but in the meantime, this sets a
fallback to search by `User`.

Longer term, I also plan on just making it a proper foreign key,
probably straight to the `User`, but that will take a few steps, and
this fallback will make it simpler to implement the data migration that
will have to happen for that.