### PR TITLE
Fix 500 error when username matches user, not userprofile

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -1615,7 +1615,10 @@ class Comment(models.Model):
         ordering = ['add_date_time', ]
 
     def user(self):
-        return UserProfile.objects.get(username=self.username)
+        try:
+            return UserProfile.objects.get(username=self.username)
+        except UserProfile.DoesNotExist:
+            return User.objects.get(username=self.username).userprofile
 
     def user_is_owner(self, user):
         """Return True if user is comment owner."""

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -361,6 +361,18 @@ class CommentTest(TestCase):
             self.c.save()
             self.assertTrue(self.c.has_been_edited())
 
+    def test_user_accepts_user_or_userprofile(self):
+        u = UserFactory()
+        self.c.username = u.username
+        self.c.save()
+        self.assertEqual(self.c.user(), u.userprofile)
+
+        c = CommentFactory()
+        up = UserProfileFactory()
+        c.username = up.username
+        c.save()
+        self.assertEqual(c.user(), up)
+
 
 class HistoryItemTest(TestCase):
     def test_status(self):


### PR DESCRIPTION
Fixes sentry error:
https://sentry.ccnmtl.columbia.edu/sentry-internal/dmt/group/1099/