### PR TITLE
add some spaces to angle brackets around emails

### DIFF
--- a/dmt/api/tests/test_views.py
+++ b/dmt/api/tests/test_views.py
@@ -381,7 +381,7 @@ class ExternalAddItemTests(APITestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data.get('title'), self.title)
         self.assertTrue(
-            'Submitted by Item Submitter <submission_email@example.com>' in
+            'Submitted by Item Submitter < submission_email@example.com >' in
             r.data.get('description')
         )
         self.assertEqual(r.data.get('type'), 'action item')
@@ -447,7 +447,7 @@ class ExternalAddItemTests(APITestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data.get('title'), self.title)
         self.assertTrue(
-            'Submitted by Item Submitter <submission_email@example.com>' in
+            'Submitted by Item Submitter < submission_email@example.com >' in
             r.data.get('description')
         )
         self.assertEqual(r.data.get('type'), 'action item')

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -127,7 +127,7 @@ def get_description(description, debug_info, name, email):
         description += '\n-----\n\nDEBUG INFO:\n' + debug_info + '\n'
 
     description += '\n-----\n\nSubmitted by ' \
-                   + name + ' <' + email + '>\n'
+                   + name + ' < ' + email + ' >\n'
     return description
 
 


### PR DESCRIPTION
working around a commonmark bug. See PMT #107242

Basically, if an item's description has something like `<foo@bar.com>`, commonmark interprets that a tag and leaves it alone, which means it doesn't render. That's... sort of what it's supposed to do in that HTML is a valid subset of markdown, and it is supposed to leave HTML tags alone. I think the least surprising behavior in this case though would be to recognize that that is not a valid HTML tag and escape the angle brackets. But I don't expect everyone to share that opinion.

So, at least for the automated description creation in the API views, the simplest thing to do is just add a couple spaces so commonmark doesn't treat it as an element.