### PR TITLE
ExternalAddItem: Allow the project to be inferred with the milestone

### DIFF
--- a/dmt/api/tests/test_views.py
+++ b/dmt/api/tests/test_views.py
@@ -461,6 +461,13 @@ class ExternalAddItemTests(APITestCase):
         self.assertTrue(unicode(self.milestone.pk) in r.data.get('milestone'))
         self.assertEqual(r.data.get('estimated_time'), '01:00:00')
 
+    def test_post_no_pid(self):
+        del self.post_data['pid']
+        r = self.client.post(reverse('external-add-item'),
+                             self.post_data,
+                             HTTP_REFERER=self.remote_host)
+        self.assertEqual(r.status_code, 200)
+
 
 class NotifyTests(APITestCase):
     def setUp(self):

--- a/dmt/api/views.py
+++ b/dmt/api/views.py
@@ -96,8 +96,14 @@ class ExternalAddItemView(APIView):
         redirect_url = request.data.get('redirect_url', '')
         append_iid = request.data.get('append_iid', '')
         description = get_description(description, debug_info, name, email)
-        project = get_object_or_404(Project, pid=pid)
-        milestone = get_milestone(mid, project)
+
+        if mid and not pid:
+            milestone = get_object_or_404(Milestone, mid=mid)
+            project = milestone.project
+            pid = project.pk
+        else:
+            project = get_object_or_404(Project, pid=pid)
+            milestone = get_milestone(mid, project)
 
         assignee = get_assignee(assignee_username, project)
         owner = get_owner(owner_username, project)


### PR DESCRIPTION
When passing in a milestone ID to the external add item view, we
shouldn't have to pass in the project ID as well, since each milestone
only belongs to one project.