### PR TITLE
:arrow_up: bootstrap 3.3.7

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -78,3 +78,7 @@ MESSAGE_TAGS = {
 
 SERVER_EMAIL = 'pmt@ccnmtl.columbia.edu'
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
+
+BOOTSTRAP3 = {
+    'base_url': '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/',
+}


### PR DESCRIPTION
changelog:
https://github.com/twbs/bootstrap/releases/tag/v3.3.7

The django-bootstrap3 package hasn't made a new release yet, but we can
use the new version by making this config change.