### PR TITLE
fix 500 error on trying to subscribe a duplicate user

### DIFF
--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -1771,6 +1771,16 @@ class TestItemAddSubscriberView(LoggedInTestMixin, TestCase):
         self.assertEqual(Notify.objects.count(), 1)
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_post_already_subscribed(self):
+        n = NotifyFactory(item=self.i)
+        self.assertEqual(Notify.objects.count(), 1)
+        url = reverse('add_subscriber', args=(self.i.pk,))
+        r = self.client.post(url, {
+            'subscriber': n.user.username
+        })
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(Notify.objects.count(), 1)
+
 
 class TestItemCreateView(LoggedInTestMixin, TestCase):
     def setUp(self):

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -479,6 +479,10 @@ class ItemAddSubscriberView(LoggedInMixin, View):
         subscriber = get_object_or_404(User, username=subscriber)
         item = get_object_or_404(Item, pk=pk)
 
+        if Notify.objects.filter(user=subscriber, item=item).exists():
+            # already an entry
+            return HttpResponseRedirect(reverse('item_detail', args=[pk]))
+
         Notify.objects.create(user=subscriber, item=item)
 
         messages.success(


### PR DESCRIPTION
if the user is already subscribed to an item, don't try to create a
duplicate. Sentry: https://sentry.io/columbia-ctl/dmt/issues/164818631/