### PR TITLE
Show project attachments

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -845,6 +845,11 @@ WHERE p.pid = m.pid
         else:
             self.projectpin_set.create(user=user)
 
+    def attachments(self):
+        return Attachment.objects.filter(
+            item__milestone__project=self).order_by(
+                '-last_mod')
+
 
 class ProjectPin(models.Model):
     project = models.ForeignKey(Project)

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -735,6 +735,10 @@ class ProjectTest(TestCase):
         self.assertEqual(projects.count(), 4,
                          'Private projects must be hidden from reports.')
 
+    def test_attachments(self):
+        a = AttachmentFactory()
+        self.assertEqual(a.item.milestone.project.attachments().count(), 1)
+
 
 class TestProjectPin(TestCase):
     def test_toggle_pin(self):

--- a/dmt/templates/main/project_detail.html
+++ b/dmt/templates/main/project_detail.html
@@ -3,6 +3,7 @@
 {% load waffle_tags %}
 {% load emoji_tags %}
 {% load dmttags %}
+{% load static %}
 
 {% block title %}Project: {{object.name}}{% endblock %}
 
@@ -17,62 +18,63 @@
 
 {% block content %}
 
-<h1 class="page-title">Project &#8226; {{object.name}}</h1>
+    <h1 class="page-title">Project &#8226; {{object.name}}</h1>
 
-<div class="object-box clearfix">
-  <div class="object-action-set clearfix">
-    <ul>
-      {% flag project_board %}
-      <li class="object-action" title="Board view">
-        <a href="{% url 'project_board' object.pid %}" class="object-action-link"><span class="glyphicon glyphicon-th-large"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Board view</span></a>
-      </li>
+    <div class="object-box clearfix">
+        <div class="object-action-set clearfix">
+            <ul>
+                {% flag project_board %}
+                <li class="object-action" title="Board view">
+                    <a href="{% url 'project_board' object.pid %}" class="object-action-link"><span class="glyphicon glyphicon-th-large"></span>
+                        <span class="object-action-text hidden-xs hidden-sm">Board view</span></a>
+                </li>
       {% endflag %}
       <li class="object-action" title="Edit project">
-        <a href="edit/" class="object-action-link"><span class="glyphicon glyphicon-pencil"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Edit project</span></a>
+          <a href="edit/" class="object-action-link"><span class="glyphicon glyphicon-pencil"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Edit project</span></a>
       </li>
       <li class="object-action" title="Add action item">
-        <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-action-item">
-          <span class="glyphicon glyphicon-check"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Add action item</span></a>
+          <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-action-item">
+              <span class="glyphicon glyphicon-check"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Add action item</span></a>
       </li>
       <li class="object-action" title="Add bug">
-        <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-bug">
-          <span class="icon-add-bug"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Add bug</span></a>
+          <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-bug">
+              <span class="icon-add-bug"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Add bug</span></a>
       </li>
       <li class="object-action" title="Add task(s) to do">
-        <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-todo">
-          <span class="glyphicon glyphicon-tasks"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Add task(s) to do</span></a>
+          <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-todo">
+              <span class="glyphicon glyphicon-tasks"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Add task(s) to do</span></a>
       </li>
       <li class="object-action" title="Add tracker">
-        <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-tracker">
-          <span class="glyphicon glyphicon-time"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Add tracker</span></a>
+          <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-tracker">
+              <span class="glyphicon glyphicon-time"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Add tracker</span></a>
       </li>
       <li class="object-action" title="Update status">
-        <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-update">
-          <span class="glyphicon glyphicon-info-sign"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Update status</span></a>
+          <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-update">
+              <span class="glyphicon glyphicon-info-sign"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Update status</span></a>
       </li>
       <li class="object-action" title="Post to forum">
-        <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-node">
-          <span class="glyphicon glyphicon-comment"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Post to forum</span></a>
+          <a href="#" class="object-action-link" data-toggle="modal" data-target="#add-node">
+              <span class="glyphicon glyphicon-comment"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Post to forum</span></a>
       </li>
       <li class="object-action" title="Activity feed">
-        <a href="{% url 'project_feed' object.pk %}">
-          <span class="icon-rss"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Activity feed</span></a>
+          <a href="{% url 'project_feed' object.pk %}">
+              <span class="icon-rss"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Activity feed</span></a>
       </li>
       {% flag project_timeline %}
       <li class="object-action" title="Timeline">
-        <a href="{% url 'project_timeline' object.pid %}" class="object-action-link"><span class="glyphicon glyphicon-list"></span>
-        <span class="object-action-text hidden-xs hidden-sm">Timeline</span></a>
+          <a href="{% url 'project_timeline' object.pid %}" class="object-action-link"><span class="glyphicon glyphicon-list"></span>
+              <span class="object-action-text hidden-xs hidden-sm">Timeline</span></a>
       </li>
       {% endflag %}
+<<<<<<< HEAD
             <li class="object-action" title="Project Tags">
                 <a href="{% url 'project_tag_list' object.pid %}"
                      class="object-action-link"><span class="glyphicon glyphicon-tags"></span>
@@ -145,6 +147,7 @@
     <li><a href="#reports" data-toggle="tab">Reports</a></li>
     <li><a href="#forum" data-toggle="tab">Forum</a></li>
     <li><a href="#updates" data-toggle="tab">Status</a></li>
+    <li><a href="#attachments" data-toggle="tab">Attachments</a></li>
 </ul>
 
 
@@ -418,6 +421,59 @@
     </div><!-- /.status-update -->
     {% endfor %}
   </div>
+
+  <div class="tab-pane fade" id="attachments">
+      {% if object.attachments.count %}
+          <h3>Item Attachments</h3>
+          {% for attachment in object.attachments %}
+              <div class="row">
+                  <div class="col-sm-2" class="attachment-thumbnail">
+                      {% if attachment.image %}
+                          {% if attachment.url %}
+                              <a href="{{attachment.url}}" title="Download this attachment"><img src="{{attachment.url}}" class="attachment-image" /></a>
+                          {% else %}
+                              <a href="{{attachment.src}}" title="Download this attachment"><img src="{{attachment.src}}" class="attachment-image" /></a>
+                          {% endif %}
+                      {% else %}
+                          <a href="{{attachment.url}}" title="Download this attachment"><img src="{% static 'img/icon-document.png' %}" class="attachment-document" /></a>
+                      {% endif %}
+                  </div><!-- attachment thumbnail -->
+                  <div class="col-sm-10">
+                      <div class="attachment-title">
+                          {% if attachment.url %}
+                              <h4>
+                                  <a href="{{attachment.url}}" title="Download this attachment">{{attachment.title|default:attachment.filename}}</a>
+                                  [{% if attachment.item.is_bug %}<img src="{{STATIC_URL}}img/tinybug.gif"
+                                                                       width="14" height="14"/> {% endif %} <a href="{{attachment.item.get_absolute_url}}">{{attachment.item.title|truncatechars:70|emoji_replace}}</a>]
+                              </h4>
+                          {% else %}
+                              <h4>
+                                  <a href="{{attachment.src}}" title="Download this attachment">{{attachment.title|default:attachment.filename}}</a>
+                                  [{% if attachment.item.is_bug %}<img src="{{STATIC_URL}}img/tinybug.gif"
+                                                                       width="14" height="14"/> {% endif %} <a href="{{attachment.item.get_absolute_url}}">{{attachment.item.title|truncatechars:70|emoji_replace}}</a>]
+                              </h4>
+                          {% endif %}
+
+
+                      </div>
+
+                      <div class="attachment-byline text-muted">
+                          Uploaded by <a href="{% url 'user_detail' attachment.user.userprofile.username %}">
+                          {{ attachment.user.userprofile.get_fullname }}
+                          </a>
+                          on {{attachment.last_mod}}
+                      </div>
+                      <div class="attachment-description">
+                          {{attachment.description|commonmark|linkify|emoji_replace}}
+                      </div>
+                  </div><!-- attachment details -->
+              </div><!-- /.row -->
+          {% endfor %}
+      {% else %}
+          <p>No item attachments</p>
+      {% endif %}
+  </div>
+  
 </div>
 {% endblock %}
 

--- a/dmt/templates/main/project_detail.html
+++ b/dmt/templates/main/project_detail.html
@@ -74,7 +74,6 @@
               <span class="object-action-text hidden-xs hidden-sm">Timeline</span></a>
       </li>
       {% endflag %}
-<<<<<<< HEAD
             <li class="object-action" title="Project Tags">
                 <a href="{% url 'project_tag_list' object.pid %}"
                      class="object-action-link"><span class="glyphicon glyphicon-tags"></span>

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -196,9 +196,3 @@ if settings.DEBUG:
     ]
 
 handler500 = 'dmt.main.views.server_error'
-
-if settings.DEBUG:
-    import debug_toolbar
-    urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls))
-    ]

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -196,3 +196,9 @@ if settings.DEBUG:
     ]
 
 handler500 = 'dmt.main.views.server_error'
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls))
+    ]


### PR DESCRIPTION
Add a tab to the project page with all the item attachments. Should make it a bit easier to locate documents that have been uploaded to the project. Implements PMT #91052.

Obviously could use a bit of design attention.

We also have a `Document` model which was once used for project level documents. That fell into disuse and we never really did anything with it since the django conversion. I'm thinking that bringing that back, now that we've worked out a good approach to uploading/storing/serving documents with S3. I played around with adding those to the tab as well, but it looks like most of the existing ones in the database are just URLs to online documentation that mostly 404. So we might want to declare bankruptcy on those and start over with a nicer S3 approach.