### PR TITLE
Fix django-debug-toolbar error

### DIFF
--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -186,4 +186,10 @@ urlpatterns = [
         'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
 ]
 
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]
+
 handler500 = 'dmt.main.views.server_error'


### PR DESCRIPTION
This addresses this error that occurs with the new django-debug-toolbar:

    u'djdt' is not a registered namespace

Based on the instructions here:
https://django-debug-toolbar.readthedocs.io/en/stable/installation.html#urlconf