### PR TITLE
:arrow_up: python-dateutil 2.6.0

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -558,7 +558,7 @@ class Project(models.Model):
         try:
             # Attempt to parse the date.
             target_date = parser.parse(target_date).date()
-        except AttributeError:
+        except TypeError:
             # If we can't parse it, it must be a datetime object, so let it
             # through.
             pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ wrapt==1.10.8
 astroid==1.4.8
 pylint==1.6.4
 six==1.10.0
-python-dateutil==2.5.3
+python-dateutil==2.6.0
 pytz==2016.7
 simpleduration==0.1.0
 ipaddress==1.0.17


### PR DESCRIPTION
they switched to raising a `TypeError` instead of `AttributeError` when
the input isn't a string: https://github.com/dateutil/dateutil/blob/master/NEWS#L24