### PR TITLE
Render feed item descriptions

### DIFF
--- a/dmt/main/feeds.py
+++ b/dmt/main/feeds.py
@@ -1,7 +1,23 @@
 from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
+from django.template import loader
+from django.utils.feedgenerator import Rss201rev2Feed
 from .models import Node, StatusUpdate, Project, Item
+
+
+class ExtendedRSSFeed(Rss201rev2Feed):
+    """
+    Create a type of RSS feed that has content:encoded elements.
+    """
+    def root_attributes(self):
+        attrs = super(ExtendedRSSFeed, self).root_attributes()
+        attrs['xmlns:content'] = 'http://purl.org/rss/1.0/modules/content/'
+        return attrs
+
+    def add_item_elements(self, handler, item):
+        super(ExtendedRSSFeed, self).add_item_elements(handler, item)
+        handler.addQuickElement(u'content:encoded', item['content_encoded'])
 
 
 class ForumFeed(Feed):
@@ -32,6 +48,7 @@ class ForumFeed(Feed):
 
 
 class StatusUpdateFeed(Feed):
+    feed_type = ExtendedRSSFeed
     title = "PMT Status Updates"
     description = "recent status updates"
     description_template = "feeds/status_item_description.html"
@@ -54,6 +71,11 @@ class StatusUpdateFeed(Feed):
 
     def item_pubdate(self, item):
         return item.added
+
+    def item_extra_kwargs(self, item):
+        description_tmp = loader.get_template(self.description_template)
+        description = description_tmp.render(dict(obj=item), None)
+        return {'content_encoded': description}
 
 
 class ProjectFeed(Feed):

--- a/dmt/main/feeds.py
+++ b/dmt/main/feeds.py
@@ -34,19 +34,13 @@ class ForumFeed(Feed):
 class StatusUpdateFeed(Feed):
     title = "PMT Status Updates"
     description = "recent status updates"
+    description_template = "feeds/status_item_description.html"
 
     def link(self):
         return settings.BASE_URL + "/status/"
 
     def items(self):
         return StatusUpdate.objects.order_by("-added")[:30]
-
-    def item_description(self, item):
-        return """<a href="%s">%s</a>:  %s""" % (
-            (settings.BASE_URL +
-             item.project.get_absolute_url()),
-            item.project.name,
-            item.body)
 
     def item_link(self, item):
         return (settings.BASE_URL + item.project.get_absolute_url() +

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -1347,6 +1347,7 @@ class TestFeeds(TestCase):
             s.author.userprofile.get_fullname()) in r.content)
         self.assertTrue("<pubDate>{}</pubDate>".format(
             s.added.strftime("%a, %02d %b %Y %H:%M:%S %z")) in r.content)
+        self.assertTrue("<content:encoded>" in r.content)
 
     def test_project_feed(self):
         p = ProjectFactory()

--- a/dmt/templates/feeds/status_item_description.html
+++ b/dmt/templates/feeds/status_item_description.html
@@ -1,0 +1,4 @@
+{% load markup %}
+{% load dmttags %}
+{% load emoji_tags %}
+{{obj.body|commonmark|linkify|emoji_replace}}


### PR DESCRIPTION
When RSS feeds from the PMT are being rendered, eg, on the production meeting wiki page:

![feed](https://cloud.githubusercontent.com/assets/7821/20967029/28df74fa-bc75-11e6-8b5d-3e326e0b3887.png)

everything is coming through escaped, which isn't very readable.

AFAICT, the "correct" way to pass formatted content along in a feed is with a `<content:encoded>` section on each item: https://developer.mozilla.org/en-US/docs/Web/RSS/Article/Why_RSS_Content_Module_is_Popular_-_Including_HTML_Contents

This PR adds that for the status update feed.

There's a second factor, which is whether the RSS plugin for mediawiki will actually respect that and render it instead of the contents of `<description>`. I won't really know that until we try it. I've only added the `<content:encoded>` to the status update feed. If we verify that it actually fixes rendering in mediawiki, we can then add it to the other feeds as well. If mediawiki ignores it, than I'll probably just pull this out and work on making a nicer plaintext description instead.