### PR TITLE
:arrow_up: postgresql 9.6, ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
+dist: trusty
 sudo: false
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
   firefox: "45.4.0esr"
 python:
   - "2.7"


### PR DESCRIPTION
Amazon RDS is currently using postgresql 9.6, so we should test against that version in travis.

Postgresql 9.6 on travis requires changing the distro from the default of Ubuntu 12.04 to 14.04, which is what we're using in production, so we should be using that here anyways. This was introduced last month: https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/