### PR TITLE
make dashboard graph timespan configurable in settings

### DIFF
--- a/dmt/main/contextprocessors.py
+++ b/dmt/main/contextprocessors.py
@@ -5,3 +5,9 @@ def graphite_base_processor(request):
     return {
         'GRAPHITE_BASE': settings.GRAPHITE_BASE,
     }
+
+
+def dashboard_graph_timespan(request):
+    return {
+        'DASHBOARD_GRAPH_TIMESPAN': settings.DASHBOARD_GRAPH_TIMESPAN,
+    }

--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -25,9 +25,10 @@ PROJECT_APPS = [
     'dmt.report',
 ]
 
-TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
-    'dmt.main.contextprocessors.graphite_base_processor'
-)
+TEMPLATES[0]['OPTIONS']['context_processors'].extend([  # noqa
+    'dmt.main.contextprocessors.graphite_base_processor',
+    'dmt.main.contextprocessors.dashboard_graph_timespan',
+])
 
 MIDDLEWARE_CLASSES += [  # noqa
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -80,3 +81,5 @@ SERVER_EMAIL = 'pmt@ccnmtl.columbia.edu'
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
 EMAIL_MAX_RETRIES = 10
+
+DASHBOARD_GRAPH_TIMESPAN = '1weeks'

--- a/dmt/templates/main/dashboard.html
+++ b/dmt/templates/main/dashboard.html
@@ -11,7 +11,7 @@
 <div class="col-xs-6">
 
 <ul class="list-group">
-<li class="list-group-item"><img src="{{GRAPHITE_BASE}}?target=stats.app.gauges.dmt.estimates.non_sm&target=stats.app.gauges.dmt.estimates.sm&_salt=1369503684.499&height=50&colorList=%236699cc%2C%23cccccc&hideLegend=true&hideAxes=true&yMin=0&width=450&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=all&from=-8months"
+<li class="list-group-item"><img src="{{GRAPHITE_BASE}}?target=stats.app.gauges.dmt.estimates.non_sm&target=stats.app.gauges.dmt.estimates.sm&_salt=1369503684.499&height=50&colorList=%236699cc%2C%23cccccc&hideLegend=true&hideAxes=true&yMin=0&width=450&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=all&from=-{{DASHBOARD_GRAPH_TIMESPAN}}"
          width="450" height="50" />
 </li>
 <li class="list-group-item"><b>{{non_sm_hours_estimated|floatformat}}</b> hours estimated in <b>{{open_non_sm_items}}</b> items</li>
@@ -22,7 +22,7 @@
 </div>
 <div class="col-xs-6">
 <ul class="list-group">
-<li class="list-group-item"><img src="{{GRAPHITE_BASE}}?target=stats.app.gauges.dmt.hours.one_week&_salt=1369503684.499&height=50&colorList=%236699cc%2C%23cccccc&hideLegend=true&hideAxes=true&yMin=0&width=450&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=all&from=-8months"
+<li class="list-group-item"><img src="{{GRAPHITE_BASE}}?target=stats.app.gauges.dmt.hours.one_week&_salt=1369503684.499&height=50&colorList=%236699cc%2C%23cccccc&hideLegend=true&hideAxes=true&yMin=0&width=450&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=all&from=-{{DASHBOARD_GRAPH_TIMESPAN}}"
          width="450" height="50" />
 </li>
 <li class="list-group-item"><b>{{breakdowns.0|floatformat}}</b> hours logged this week</li>
@@ -60,7 +60,7 @@
 <tr>
     <td><a href="{{project.get_absolute_url}}">{{project.name}}</a></td>
   <td><b>{{project.recent_hours|floatformat}}</b> hours logged</td>
-    <td><img src="{{GRAPHITE_BASE}}?target=stats.app.gauges.dmt.projects.{{project.pid}}.hours_logged&target=stats.app.gauges.dmt.projects.{{project.pid}}.hours_estimated&_salt=1369503684.466&height=10&colorList=%2366cc66%2C%23cc6666&hideLegend=true&hideAxes=true&yMin=0&width=50&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=stacked&from=-8months"
+    <td><img src="{{GRAPHITE_BASE}}?target=stats.app.gauges.dmt.projects.{{project.pid}}.hours_logged&target=stats.app.gauges.dmt.projects.{{project.pid}}.hours_estimated&_salt=1369503684.466&height=10&colorList=%2366cc66%2C%23cc6666&hideLegend=true&hideAxes=true&yMin=0&width=50&bgcolor=%23ffffff&hideGrid=true&graphOnly=true&areaMode=stacked&from=-{{DASHBOARD_GRAPH_TIMESPAN}}"
          width="50" height="10" /></td>
 </tr>
 {% endfor %}


### PR DESCRIPTION
since moved our graphite server, we don't have the old metrics anymore,
so the graphs should be adjusted now and then until we get a year or so
of data up there. This should make it a little simpler.