### PR TITLE
Kanban view

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -895,6 +895,38 @@ class Milestone(models.Model):
             'owner_user', 'assigned_user',
             'owner_user__userprofile', 'assigned_user__userprofile')
 
+    def open_items(self):
+        return Item.objects.filter(
+            milestone=self,
+            status__in=['OPEN']
+        ).order_by('-target_date').select_related(
+            'owner_user', 'assigned_user',
+            'owner_user__userprofile', 'assigned_user__userprofile')
+
+    def inprogress_items(self):
+        return Item.objects.filter(
+            milestone=self,
+            status__in=['INPROGRESS']
+        ).order_by('-target_date').select_related(
+            'owner_user', 'assigned_user',
+            'owner_user__userprofile', 'assigned_user__userprofile')
+
+    def resolved_items(self):
+        return Item.objects.filter(
+            milestone=self,
+            status__in=['RESOLVED']
+        ).order_by('-target_date').select_related(
+            'owner_user', 'assigned_user',
+            'owner_user__userprofile', 'assigned_user__userprofile')
+
+    def verified_items(self):
+        return Item.objects.filter(
+            milestone=self,
+            status__in=['VERIFIED']
+        ).order_by('-target_date').select_related(
+            'owner_user', 'assigned_user',
+            'owner_user__userprofile', 'assigned_user__userprofile')
+
     def get_absolute_url(self):
         return "/milestone/%d/" % self.mid
 

--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -887,45 +887,28 @@ class Milestone(models.Model):
         db_table = u'milestones'
         ordering = ['target_date', 'name', ]
 
-    def active_items(self):
+    def filter_items_by_status(self, statuses):
         return Item.objects.filter(
             milestone=self,
-            status__in=['OPEN', 'RESOLVED', 'INPROGRESS']
+            status__in=statuses
         ).order_by('-target_date').select_related(
             'owner_user', 'assigned_user',
             'owner_user__userprofile', 'assigned_user__userprofile')
+
+    def active_items(self):
+        return self.filter_items_by_status(['OPEN', 'RESOLVED', 'INPROGRESS'])
 
     def open_items(self):
-        return Item.objects.filter(
-            milestone=self,
-            status__in=['OPEN']
-        ).order_by('-target_date').select_related(
-            'owner_user', 'assigned_user',
-            'owner_user__userprofile', 'assigned_user__userprofile')
+        return self.filter_items_by_status(['OPEN'])
 
     def inprogress_items(self):
-        return Item.objects.filter(
-            milestone=self,
-            status__in=['INPROGRESS']
-        ).order_by('-target_date').select_related(
-            'owner_user', 'assigned_user',
-            'owner_user__userprofile', 'assigned_user__userprofile')
+        return self.filter_items_by_status(['INPROGRESS'])
 
     def resolved_items(self):
-        return Item.objects.filter(
-            milestone=self,
-            status__in=['RESOLVED']
-        ).order_by('-target_date').select_related(
-            'owner_user', 'assigned_user',
-            'owner_user__userprofile', 'assigned_user__userprofile')
+        return self.filter_items_by_status(['RESOLVED'])
 
     def verified_items(self):
-        return Item.objects.filter(
-            milestone=self,
-            status__in=['VERIFIED']
-        ).order_by('-target_date').select_related(
-            'owner_user', 'assigned_user',
-            'owner_user__userprofile', 'assigned_user__userprofile')
+        return self.filter_items_by_status(['VERIFIED'])
 
     def get_absolute_url(self):
         return "/milestone/%d/" % self.mid

--- a/dmt/main/tests/test_models.py
+++ b/dmt/main/tests/test_models.py
@@ -199,6 +199,61 @@ class MilestoneTest(TestCase):
         m = MilestoneFactory()
         self.assertEqual(m.estimated_time_remaining(), 0.)
 
+    def test_active_items(self):
+        i = ItemFactory(status='OPEN')
+        i2 = ItemFactory(status='INPROGRESS', milestone=i.milestone)
+        i3 = ItemFactory(status='RESOLVED', milestone=i.milestone)
+        i4 = ItemFactory(status='VERIFIED', milestone=i.milestone)
+        r = i.milestone.active_items()
+        self.assertIn(i, r)
+        self.assertIn(i2, r)
+        self.assertIn(i3, r)
+        self.assertNotIn(i4, r)
+
+    def test_open_items(self):
+        i = ItemFactory(status='OPEN')
+        i2 = ItemFactory(status='INPROGRESS', milestone=i.milestone)
+        i3 = ItemFactory(status='RESOLVED', milestone=i.milestone)
+        i4 = ItemFactory(status='VERIFIED', milestone=i.milestone)
+        r = i.milestone.open_items()
+        self.assertIn(i, r)
+        self.assertNotIn(i2, r)
+        self.assertNotIn(i3, r)
+        self.assertNotIn(i4, r)
+
+    def test_inprogress_items(self):
+        i = ItemFactory(status='OPEN')
+        i2 = ItemFactory(status='INPROGRESS', milestone=i.milestone)
+        i3 = ItemFactory(status='RESOLVED', milestone=i.milestone)
+        i4 = ItemFactory(status='VERIFIED', milestone=i.milestone)
+        r = i.milestone.inprogress_items()
+        self.assertNotIn(i, r)
+        self.assertIn(i2, r)
+        self.assertNotIn(i3, r)
+        self.assertNotIn(i4, r)
+
+    def test_resolved_items(self):
+        i = ItemFactory(status='OPEN')
+        i2 = ItemFactory(status='INPROGRESS', milestone=i.milestone)
+        i3 = ItemFactory(status='RESOLVED', milestone=i.milestone)
+        i4 = ItemFactory(status='VERIFIED', milestone=i.milestone)
+        r = i.milestone.resolved_items()
+        self.assertNotIn(i, r)
+        self.assertNotIn(i2, r)
+        self.assertIn(i3, r)
+        self.assertNotIn(i4, r)
+
+    def test_verified_items(self):
+        i = ItemFactory(status='OPEN')
+        i2 = ItemFactory(status='INPROGRESS', milestone=i.milestone)
+        i3 = ItemFactory(status='RESOLVED', milestone=i.milestone)
+        i4 = ItemFactory(status='VERIFIED', milestone=i.milestone)
+        r = i.milestone.verified_items()
+        self.assertNotIn(i, r)
+        self.assertNotIn(i2, r)
+        self.assertNotIn(i3, r)
+        self.assertIn(i4, r)
+
 
 class ItemTest(TestCase):
     def test_gau(self):

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -162,6 +162,11 @@ class TestProjectViews(LoggedInTestMixin, TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertContains(r, 'id="milestones"')
 
+    def test_project_kanban(self):
+        r = self.c.get(reverse('project_kanban', args=[self.p.pid]))
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'id="milestones"')
+
     def test_project_report_page(self):
         r = self.c.get(self.p.get_absolute_url() + '#reports')
         self.assertEqual(r.status_code, 200)

--- a/dmt/templates/main/project_kanban.html
+++ b/dmt/templates/main/project_kanban.html
@@ -1,0 +1,108 @@
+{% extends 'base.html' %}
+{% load bootstrap3 %}
+
+{% block title %}Project: {{object.name}}{% endblock %}
+
+{% block extraclass %} class="project-page"{% endblock %}
+
+{% block primarynavtabs %}
+{% endblock %}
+
+{% block primarynavtabsright %}
+{% endblock %}
+
+
+{% block css %}
+        <style>
+         .item {
+             width: 175px;
+             border: #666 solid 1px;
+             padding: 5px;
+             margin: 5px;
+         }
+         .milestone {
+             background-color: #eee;
+             list-style-type: none;
+             padding: 5px;
+         }
+         .item-user {
+             text-align: right;
+         }
+
+         .pr0 .item-title { background-color: #eee; }         
+         .pr1 .item-title { background-color: #eff; }
+         .pr2 .item-title { background-color: #cfc; }
+         .pr3 .item-title { background-color: #fec; }
+         .pr4 .item-title { background-color: #fcc; }
+
+         table#milestones {
+             background-color: #fff;
+         }
+         
+        </style>
+{% endblock %}
+
+{% block content %}
+        <table class="table table-condensed" id="milestones">
+            <thead>
+                <tr>
+                    <th>Milestone</th>
+                    <th><span class="dmt-open">OPEN</span></th>
+                    <th><span class="inprogress">IN PROGRESS</span></th>
+                    <th><span class="resolved">RESOLVED</span></th>
+                    <th><span class="verified">VERIFIED</span></th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for milestone in object.open_milestones %}
+                <tr>
+                    <th>{{milestone.name}}<br />
+                        {{milestone.target_date}}
+                    </th>
+                    <td>
+                        {% for item in milestone.open_items %}
+                            <div class="item pr{{item.priority}}" id="item-{{item.iid}}" data-iid="{{item.iid}}">
+                                <div class="item-title">{% if item.is_bug %}<img src="{{STATIC_URL}}img/tinybug.gif"
+                                                                                 width="14" height="14"/> {% endif %}
+                                <a href="{{item.get_absolute_url}}">{{item.title|truncatechars:70}}</a></div>
+                                <div class="item-user">
+                                    <span class="glyphicon glyphicon-user" aria-hidden="true"></span> <a href="{{item.assigned_user.userprofile.get_absolute_url}}"
+                                                                                                      >{{ item.assigned_user.userprofile.get_fullname }}</a></div>
+                            </div>
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% for item in milestone.inprogress_items %}
+                            <div class="item pr{{item.priority}}" id="item-{{item.iid}}" data-iid="{{item.iid}}">
+                                <div class="item-title">{% if item.is_bug %}<img src="{{STATIC_URL}}img/tinybug.gif"
+                                                                                 width="14" height="14"/> {% endif %}<a href="{{item.get_absolute_url}}">{{item.title|truncatechars:70}}</a></div>
+                                <div class="item-user">
+                                    <span class="glyphicon glyphicon-user" aria-hidden="true"></span> <a href="{{item.assigned_user.userprofile.get_absolute_url}}"
+                                                                                                      >{{ item.assigned_user.userprofile.get_fullname }}</a></div>
+                            </div>
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% for item in milestone.resolved_items %}
+                            <div class="item pr{{item.priority}}" id="item-{{item.iid}}" data-iid="{{item.iid}}">
+                                <div class="item-title">{% if item.is_bug %}<img src="{{STATIC_URL}}img/tinybug.gif"
+                                                                                 width="14" height="14"/> {% endif %}<a href="{{item.get_absolute_url}}">{{item.title|truncatechars:70}}</a></div>
+                                <div class="item-user">
+                                    <span class="glyphicon glyphicon-user" aria-hidden="true"></span> <a href="{{item.owner_user.userprofile.get_absolute_url}}"
+                                                                                                      >{{ item.owner_user.userprofile.get_fullname }}</a></div>                                
+                            </div>
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% for item in milestone.verified_items %}
+                            <div class="item pr{{item.priority}}" id="item-{{item.iid}}" data-iid="{{item.iid}}">
+                                {% if item.is_bug %}<img src="{{STATIC_URL}}img/tinybug.gif"
+                                                         width="14" height="14"/> {% endif %}<a href="{{item.get_absolute_url}}">{{item.title|truncatechars:70}}</a>
+                        </div>
+                        {% endfor %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+{% endblock %}

--- a/dmt/urls.py
+++ b/dmt/urls.py
@@ -133,6 +133,9 @@ urlpatterns = [
     url(r'^project/(?P<pk>\d+)/board/$', ProjectDetailView.as_view(
         template_name="main/project_board.html"),
         name='project_board'),
+    url(r'^project/(?P<pk>\d+)/kanban/$', ProjectDetailView.as_view(
+        template_name="main/project_kanban.html"),
+        name='project_kanban'),
     url(r'^project/(?P<pk>\d+)/timeline/$', ProjectTimeLineView.as_view(),
         name='project_timeline'),
     url(r'^project/(?P<pk>\d+)/add_bug/$',


### PR DESCRIPTION
Adds a very basic kanban board view of a project.

View only so far. Unlike the other board view, there's no interaction here. Mostly that's just because there's a lot of work to be done to implement that and I see some value first in just having the view available.

Anyway, for a project, add `kanban/` to the end of the URL (no links to it yet until at least @zmustapha has a chance to clean up the design a bit) and you get something like this:

![kanban](https://cloud.githubusercontent.com/assets/7821/22591479/bfe8b1da-ea0c-11e6-869c-684741a93e8b.png)

Each milestone in the project is a row, then there are columns for 'OPEN', 'IN PROGRESS', 'RESOLVED', and 'VERIFIED'.

Items are shown as concisely as possible, with just the title and assignee (for open/in progress) or owner (for resolved) and some light color coding for priority. Items in the verified column are further downplayed, showing just the title in an attempt to minimize the space they take up.

The primary goal of a kanban board is just to visualize the current state of work so you can see bottlenecks and get a sense of whether things are progressing or getting held up somewhere. I think this basically accomplishes that within the limitations of the PMT's model.

Further work I'm thinking about in this direction:

* obviously, supporting drag+drop interaction directly with the board. This just gets tricky because changing status (eg, moving from resolved to verified) often ought to only be done by one particular user and a UX where only certain items can be interacted with sounds annoying. Most status changes also ought to be accompanied by eg, an explanatory comment or logging some hours. So... it just gets ugly and complicated. At some point we may decide that the convenience of interacting with it this way is a bigger win than the issues it introduces, but let's live with it as view-only for now.
* there should be a version that has has users on the project as the rows instead of milestones. That would help visualize if one particular user is overloaded or bottlenecked across milestones. maybe a way to toggle between user/milestone view.
* on the fence about whether to include time estimates on the items. Right now I think it would be more visual noise than it's worth. If we were on t-shirt sizing for estimates (S/M/L/XL), that could be displayed very succinctly and would work better.