### PR TITLE
construct timedelta with days rather than years

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -536,7 +536,7 @@ class Project(models.Model):
             return
         if sm.target_date < m.target_date:
             # make it a solid year further out than the other milestone
-            sm.target_date = m.target_date + timedelta(years=1)
+            sm.target_date = m.target_date + timedelta(days=365)
             sm.save()
 
     def someday_maybe_milestone(self):


### PR DESCRIPTION
I *always* forget that `timedelta` only takes certain intervals and that
`years` isn't one. :package: 

sentry: https://sentry.io/columbia-ctl/dmt/issues/215121947/