### PR TITLE
rename 'messages' to 'chat_messages' on archive page

### DIFF
--- a/dmt/chat/tests/test_views.py
+++ b/dmt/chat/tests/test_views.py
@@ -64,4 +64,4 @@ class TestViews(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.context_data['project'], m.project)
-        self.assertTrue(m in response.context_data['messages'])
+        self.assertTrue(m in response.context_data['chat_messages'])

--- a/dmt/chat/views.py
+++ b/dmt/chat/views.py
@@ -102,7 +102,7 @@ class ChatArchiveDate(TemplateView):
         project = get_object_or_404(Project, pid=pid)
         (year, month, day) = date.split('-')
         d = datetime(year=int(year), month=int(month), day=int(day))
-        context['messages'] = project.message_set.filter(
+        context['chat_messages'] = project.message_set.filter(
             added__year=year,
             added__month=month,
             added__day=day)

--- a/dmt/templates/chat/archive_date.html
+++ b/dmt/templates/chat/archive_date.html
@@ -8,7 +8,7 @@
 <h1>Archive for {{date.date}}: <a href="{{project.get_absolute_url}}">{{project.name}}</a></h1>
 
 <div id="log">
-{% for message in messages %}
+{% for message in chat_messages %}
 <div class="row" id="message-{{message.id}}">
         <div class="col-md-1 timestamp"><a href="{{message.get_absolute_url}}">{{message.added|date:"H:i"}}</a></div>
         <div class="col-md-2 nick">&lt;{{message.user.username}}&gt;</div>


### PR DESCRIPTION

![chat_messages](https://cloud.githubusercontent.com/assets/7821/23068026/c7c592ac-f519-11e6-9ad7-cb00dbd2039c.png)

PMT #110076

this avoids a conflict with the standard django messages framework,
which was causing it to display the messages a second time.