### PR TITLE
force default datetimes on some test messages

### DIFF
--- a/dmt/chat/tests/test_models.py
+++ b/dmt/chat/tests/test_models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.test import TestCase
 from .factories import MessageFactory
 from ..models import Room
@@ -20,6 +22,6 @@ class TestRoom(TestCase):
         self.assertTrue(m in r.recent_messages())
 
     def test_unique_dates(self):
-        m = MessageFactory()
+        m = MessageFactory(added=datetime(year=2017, month=1, day=1))
         r = Room(project=m.project)
         self.assertTrue(m.added.date() in [d.date() for d in r.unique_dates()])

--- a/dmt/chat/tests/test_views.py
+++ b/dmt/chat/tests/test_views.py
@@ -1,6 +1,8 @@
 import json
 import unittest
 
+from datetime import datetime
+
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
 
@@ -56,7 +58,7 @@ class TestViews(unittest.TestCase):
         self.assertEqual(response.context_data['project'], m.project)
 
     def test_archive_date(self):
-        m = MessageFactory()
+        m = MessageFactory(added=datetime(year=2017, month=1, day=1))
         request = RequestFactory().get(m.get_absolute_url())
         response = ChatArchiveDate.as_view()(
             request, pid=m.project.pid,


### PR DESCRIPTION
PMT #110068 seems to be because the database default/auto_now_add times
gets a timestamp and the python datetime defaults don't (or maybe
vice-versa, I'm not sure). So if the tests get run in the right window,
the message timestamp can appear to be in two different dates at once.

So, for the tests where that matters, just force the default to be set
from a python datestamp so it's consistent.