### PR TITLE
put CSRF token code back into chat

### DIFF
--- a/media/js/src/chat.js
+++ b/media/js/src/chat.js
@@ -28,6 +28,36 @@ require([
     'jquery',
     'utils/markdown_renderer'
 ], function(domReady, $, MarkdownRenderer) {
+    function getCookie(name) {
+        var cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            var cookies = document.cookie.split(';');
+            for (var i = 0; i < cookies.length; i++) {
+                var cookie = jQuery.trim(cookies[i]);
+                // Does this cookie string begin with the name we want?
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(
+                        cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+    var csrftoken = getCookie('csrftoken');
+
+    function csrfSafeMethod(method) {
+        // these HTTP methods do not require CSRF protection
+        return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+    }
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                xhr.setRequestHeader('X-CSRFToken', csrftoken);
+            }
+        }
+    });
+
     var conn;
     var log = $('#log');
 


### PR DESCRIPTION
Somehow this got lost in the markdown stuff. PMT enforces CSRF
protection, so the JS needs to pass the token with AJAX requests.