### PR TITLE
handle additional temporary SES emails

### DIFF
--- a/dmt/main/tasks.py
+++ b/dmt/main/tasks.py
@@ -249,7 +249,10 @@ def send_email(self, subject, body, to_addresses):
             subject,
             body, settings.SERVER_EMAIL,
             to_addresses, fail_silently=settings.DEBUG)
-    except smtplib.SMTPAuthenticationError as exc:
+    except (smtplib.SMTPAuthenticationError,
+            smtplib.SMTPServerDisconnected,
+            smtplib.SMTPConnectError,
+            smtplib.SMTPDataError) as exc:
         if self.request.retries > settings.EMAIL_MAX_RETRIES:
             raise exc
         else:


### PR DESCRIPTION
PMT #110194

the AWS/SES outage flushed out some other exceptions that SES/smtplib
can raise when it is down. Since *most* of the time, we expect SES
outages to be transient, we should at least try our usual backoff/retry
strategy to deal with them.