### PR TITLE
Use -sm- instead of -md- for chat bootstrap classes

### DIFF
--- a/dmt/templates/chat/chat.html
+++ b/dmt/templates/chat/chat.html
@@ -36,15 +36,15 @@
     {% for message in room.recent_messages %}
         {% ifchanged message.added.date %}
             <div class="row">
-                <div class="col-md-12 bg-info">
+                <div class="col-sm-12 bg-info">
                     {{message.added.date}}
                 </div>
             </div>
         {% endifchanged %}
 <div class="row">
-        <div class="col-md-1 timestamp">{{message.added|date:"H:i"}}</div>
-        <div class="col-md-2 nick"><a href="{% url 'user_detail' message.user.userprofile.username %}">{{message.user.get_full_name}}</a></div>
-        <div class="col-md-9 ircmessage">{{message.text|commonmark|linkify|emoji_replace}}</div>
+        <div class="col-sm-1 timestamp">{{message.added|date:"H:i"}}</div>
+        <div class="col-sm-2 nick"><a href="{% url 'user_detail' message.user.userprofile.username %}">{{message.user.get_full_name}}</a></div>
+        <div class="col-sm-9 ircmessage">{{message.text|commonmark|linkify|emoji_replace}}</div>
 </div>
 {% endfor %}
 </div>
@@ -52,8 +52,8 @@
 <form id="msg_form" class="form-inline post-form">
     {% csrf_token %}
     <div class="row" id="chat-message-form">
-        <div class="col-md-3"><input type="submit" class="btn btn-primary" value="Post" /></div>
-        <div class="col-md-9">
+        <div class="col-sm-3"><input type="submit" class="btn btn-primary" value="Post" /></div>
+        <div class="col-sm-9">
             <input type="text" id="text-input" name="text" class="form-control" />
         </div>
     </div>

--- a/media/js/src/chat.js
+++ b/media/js/src/chat.js
@@ -239,12 +239,12 @@ require([
         if (minutes < 10) {
             minutes = '0' + minutes;
         }
-        entry.append('<div class="col-md-1 timestamp">' + hours + ':' +
+        entry.append('<div class="col-sm-1 timestamp">' + hours + ':' +
                      minutes + '</div>');
-        entry.append('<div class="col-md-2 nick"><a href="' + data.userURL +
+        entry.append('<div class="col-sm-2 nick"><a href="' + data.userURL +
                      '">' + data.fullname + '</a></div>');
         var attr = 'message_text';
-        entry.append('<div class="col-md-9 ircmessage">' +
+        entry.append('<div class="col-sm-9 ircmessage">' +
                      renderer.render(data[attr]) + '</div>');
         appendLog(entry);
         // if we get a message from a user, that's


### PR DESCRIPTION
The layout was switching to the vertical / mobile style when my browser
window was still pretty wide, and could remain in the horizontal view.