### PR TITLE
Omit leading slash from static files

### DIFF
--- a/dmt/templates/base.html
+++ b/dmt/templates/base.html
@@ -50,9 +50,9 @@
 
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
   <script src="{% bootstrap_javascript_url %}"></script>
-  <script src="{% static '/media/js/src/utils/bootstrap_tabs.js' %}"></script>
-  <script src="{% static '/media/js/src/utils/bootstrap_modals.js' %}"></script>
-  <script src="{% static '/media/js/src/utils/bootstrap_tooltips.js' %}"></script>
+  <script src="{% static 'media/js/src/utils/bootstrap_tabs.js' %}"></script>
+  <script src="{% static 'media/js/src/utils/bootstrap_modals.js' %}"></script>
+  <script src="{% static 'media/js/src/utils/bootstrap_tooltips.js' %}"></script>
 
   <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
   <!--[if lt IE 9]>


### PR DESCRIPTION
This addresses the following error from django-storages that's ocurring
on staging:
```
SuspiciousOperation at /user/agarber/
Attempted access to '/media/js/src/utils/bootstrap_tabs.js' denied.
Request Method: GET
Request URL:    https://dmt.stage.ccnmtl.columbia.edu/user/agarber/
Django Version: 1.10.6
Exception Type: SuspiciousOperation
Exception Value:
Attempted access to '/media/js/src/utils/bootstrap_tabs.js' denied.
Exception Location:
/var/www/dmt/releases/blue/dmt/ve/lib/python2.7/site-packages/storages/backends/s3boto.py
in _normalize_name, line 365
```