### PR TITLE
:arrow_up: django-filters 1.0.2

### DIFF
--- a/dmt/main/filters.py
+++ b/dmt/main/filters.py
@@ -5,31 +5,46 @@ from django_filters import (
     ChoiceFilter,
 )
 
+from .models import Client, Project
+
 
 class ClientFilter(FilterSet):
-    lastname = CharFilter(label='Last Name', lookup_type='icontains')
-    firstname = CharFilter(label='First Name', lookup_type='icontains')
-    department = CharFilter(lookup_type='icontains')
-    school = CharFilter(lookup_type='icontains')
-    email = CharFilter(lookup_type='icontains')
-    phone = CharFilter(label='Phone Number', lookup_type='icontains')
-    comments = CharFilter(lookup_type='icontains')
+    lastname = CharFilter(label='Last Name', lookup_expr='icontains')
+    firstname = CharFilter(label='First Name', lookup_expr='icontains')
+    department = CharFilter(lookup_expr='icontains')
+    school = CharFilter(lookup_expr='icontains')
+    email = CharFilter(lookup_expr='icontains')
+    phone = CharFilter(label='Phone Number', lookup_expr='icontains')
+    comments = CharFilter(lookup_expr='icontains')
     user = ModelChoiceFilter(
         queryset=User.objects.filter(
             ~Q(username__startswith='grp_')
         ))
 
+    class Meta:
+        model = Client
+        fields = ['lastname', 'firstname', 'department', 'school', 'email',
+                  'phone', 'comments', 'user']
+
 
 class ProjectFilter(FilterSet):
-    name = CharFilter(label='Project Name', lookup_type='icontains')
+    name = CharFilter(label='Project Name', lookup_expr='icontains')
     projnum = NumberFilter(label='Project Number')
     caretaker_user = ModelChoiceFilter(
         queryset=User.objects.filter(~Q(username__startswith='grp_')))
-    description = CharFilter(lookup_type='icontains')
+    description = CharFilter(lookup_expr='icontains')
+
+    class Meta:
+        model = Project
+        fields = ['name', 'projnum', 'caretaker_user', 'description']
 
 
 class UserFilter(FilterSet):
-    fullname = CharFilter(label='Full name', lookup_type='icontains')
+    fullname = CharFilter(label='Full name', lookup_expr='icontains')
     status = ChoiceFilter(choices=[("", "All statuses"),
                                    ("active", "Active"),
                                    ("inactive", "Inactive")])
+
+    class Meta:
+        model = User
+        fields = ['fullname', 'status']

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ django-extensions==1.7.7
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-impersonate==1.1
-django-filter==0.15.3
+django-filter==1.0.2
 django-crispy-forms==1.6.1
 djangorestframework==3.6.2
 django-taggit==0.22.0


### PR DESCRIPTION
some API changes since 0.15.3

* they renamed `lookup_type` to `lookup_expr`
* now require explicit setting of the model and fields on a filterset

On the plus side, there is now integration between `django-filter` and
`djangorestframework`, so that could be interesting:
https://django-filter.readthedocs.io/en/latest/guide/rest_framework.html