### PR TITLE
Move milestone unicode bugfix

### DIFF
--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -838,7 +838,7 @@ class TestMilestoneDetailView(LoggedInTestMixin, TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertContains(
             r,
-            'Moved the following items to <strong>{}</strong>:'.format(
+            u'Moved the following items to <strong>{}</strong>:'.format(
                 m2.name))
 
     def test_post_move_with_unicode(self):
@@ -864,8 +864,7 @@ class TestMilestoneDetailView(LoggedInTestMixin, TestCase):
         r = self.client.get(r.url)
         self.assertEqual(r.status_code, 200)
         self.assertContains(
-            r,
-            'Moved the following items to <strong>{}</strong>:'.format(
+            r, u'Moved the following items to <strong>{}</strong>:'.format(
                 m2.name))
 
 

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -841,6 +841,33 @@ class TestMilestoneDetailView(LoggedInTestMixin, TestCase):
             'Moved the following items to <strong>{}</strong>:'.format(
                 m2.name))
 
+    def test_post_move_with_unicode(self):
+        """ see PMT #111049 """
+        m2 = MilestoneFactory(project=self.m.project,
+                              name=u'\u201d')
+        ItemFactory(milestone=self.m, title=u'\u201d')
+        self.assertEqual(self.m.active_items().count(), 1)
+
+        items = self.m.active_items().order_by('title')
+        r = self.client.post(self.m.get_absolute_url(), {
+            'action': 'move',
+            'move_to': m2.mid,
+            '_selected_action': [items[0].pk],
+        })
+        self.assertEqual(r.status_code, 302)
+
+        m1_items = self.m.active_items().order_by('title')
+        m2_items = m2.active_items().order_by('title')
+        self.assertEqual(m1_items.count(), 0)
+        self.assertEqual(m2_items.count(), 1)
+
+        r = self.client.get(r.url)
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(
+            r,
+            'Moved the following items to <strong>{}</strong>:'.format(
+                m2.name))
+
 
 class TestItemViews(LoggedInTestMixin, TestCase):
     def setUp(self):

--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from urlparse import urljoin
 from django import forms
 from django.conf import settings


### PR DESCRIPTION
Per PMT #111049 and sentry DMT-N, moving items between milestones fails when the item has non-ascii unicode chars in the title. Likely the same issue with reassign, etc.

This uses the django recommended approach (https://docs.djangoproject.com/en/1.11/ref/unicode/) of `from __future__ import unicode_literals`, which should solve this issue and other similar ones and by py2/py3 compatible.