### PR TITLE
remove opbeat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -138,8 +138,7 @@ gunicorn==19.7.1
 django-storages==1.5.2
 django-cacheds3storage==0.1.2
 django-markwhat==1.5.1
-urllib3==1.21.1
-opbeat==3.5.2
+
 django-s3sign==0.1.3
 django-smtp-ssl==1.0
 


### PR DESCRIPTION
I originally set up opbeat integration on a couple apps to see if we
liked it better than sentry. It doesn't seem to have gotten any traction
so I'm removing it.