### PR TITLE
eslint / jscs fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,4 @@ travis: $(JS_SENTINAL) parallel-tests jstest integration
 
 js: media/main-built.js media/chat-built.js
 
-eslint: $(JS_SENTINAL) media/js/src
-	$(NODE_MODULES)/.bin/eslint media/js/src/**
-
 .PHONY: js

--- a/media/js/tests/unit/models/client.spec.js
+++ b/media/js/tests/unit/models/client.spec.js
@@ -1,3 +1,5 @@
+/* eslint-env qunit */
+/* global sinon */
 define(
     ['jquery', '../../../src/models/client'],
     function($, Client) {
@@ -21,10 +23,13 @@ define(
             client.save();
 
             assert.ok($.ajax.calledOnce, 'made an ajax request');
-            assert.strictEqual($.ajax.getCall(0).args[0].url, '/drf/clients/7/',
-                         'called correct url');
-            assert.ok($.ajax.getCall(0).args[0].data.match(email),
-                      'has correct data in payload');
+            assert.strictEqual(
+                $.ajax.getCall(0).args[0].url,
+                '/drf/clients/7/',
+                'called correct url');
+            assert.ok(
+                $.ajax.getCall(0).args[0].data.match(email),
+                'has correct data in payload');
         });
 
         QUnit.test('url() should return correct url', function(assert) {

--- a/media/js/tests/unit/models/item.spec.js
+++ b/media/js/tests/unit/models/item.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env qunit */
 define(['../../../src/models/item'], function(Item) {
     QUnit.test('should be able to create an instance', function(assert) {
         assert.expect(2);

--- a/media/js/tests/unit/models/notify.spec.js
+++ b/media/js/tests/unit/models/notify.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env qunit */
 define(['../../../src/models/notify'], function(Notify) {
     QUnit.test('should be able to create an instance', function(assert) {
         assert.expect(2);

--- a/media/js/tests/unit/utils/markdown_toolbar_controller.spec.js
+++ b/media/js/tests/unit/utils/markdown_toolbar_controller.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env qunit */
 define([
     '../../../src/utils/markdown_toolbar_controller'
 ], function(MarkdownToolbarController) {
@@ -119,7 +120,9 @@ define([
         };
         var rendered = 'abcdef- ';
         var c = new MarkdownToolbarController();
-        assert.strictEqual(c.render(data, text.length, text.length, text), rendered);
+        assert.strictEqual(
+            c.render(data, text.length, text.length, text),
+            rendered);
         assert.strictEqual(c.selectionStart, 0);
         assert.strictEqual(c.selectionEnd, 8);
 
@@ -160,7 +163,9 @@ define([
         };
         var rendered = 'abcdef1. ';
         var c = new MarkdownToolbarController();
-        assert.strictEqual(c.render(data, text.length, text.length, text), rendered);
+        assert.strictEqual(
+            c.render(data, text.length, text.length, text),
+            rendered);
         assert.strictEqual(c.selectionStart, 0);
         assert.strictEqual(c.selectionEnd, 9);
 

--- a/media/js/tests/unit/utils/utils.spec.js
+++ b/media/js/tests/unit/utils/utils.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env qunit */
 define([
     '../../../src/utils/utils'
 ], function(Utils) {

--- a/media/js/tests/unit/views/client.spec.js
+++ b/media/js/tests/unit/views/client.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env qunit */
 define(
     [
         'jquery',

--- a/media/js/tests/unit/views/item.spec.js
+++ b/media/js/tests/unit/views/item.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env qunit */
 define(
     [
         'jquery',


### PR DESCRIPTION
The eslint make target was defined in Makefile, overriding the target in
js.mk that correctly picks up all the JS directories. So I've uncovered
and fixed some eslint problems.

Also, it looks like jscs is being run on jenkins, not on travis.
Eventually I'll clean this up - we can just get rid of jshint/jscs in
favor of eslint.