### PR TITLE
Resolving time-based test failures

### DIFF
--- a/dmt/chat/tests/test_models.py
+++ b/dmt/chat/tests/test_models.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.test import TestCase
 from .factories import MessageFactory
 from ..models import Room
@@ -22,6 +20,8 @@ class TestRoom(TestCase):
         self.assertTrue(m in r.recent_messages())
 
     def test_unique_dates(self):
-        m = MessageFactory(added=datetime(year=2017, month=1, day=1))
-        r = Room(project=m.project)
-        self.assertTrue(m.added.date() in [d.date() for d in r.unique_dates()])
+        with self.settings(USE_TZ=False):
+            m = MessageFactory()
+            r = Room(project=m.project)
+            self.assertTrue(
+                m.added.date() in [d.date() for d in r.unique_dates()])

--- a/dmt/chat/tests/test_views.py
+++ b/dmt/chat/tests/test_views.py
@@ -1,10 +1,7 @@
 import json
-import unittest
-
-from datetime import datetime
 
 from django.core.urlresolvers import reverse
-from django.test import RequestFactory
+from django.test import TestCase, RequestFactory
 
 from dmt.main.models import Item
 
@@ -13,7 +10,7 @@ from ..views import Chat, FreshToken, ChatPost, ChatArchive, ChatArchiveDate
 from ..models import Message
 
 
-class TestViews(unittest.TestCase):
+class TestViews(TestCase):
     def test_chat(self):
         m = MessageFactory()
         request = RequestFactory().get(reverse('project-chat',
@@ -102,12 +99,14 @@ class TestViews(unittest.TestCase):
         self.assertEqual(response.context_data['project'], m.project)
 
     def test_archive_date(self):
-        m = MessageFactory(added=datetime(year=2017, month=1, day=1))
-        request = RequestFactory().get(m.get_absolute_url())
-        response = ChatArchiveDate.as_view()(
-            request, pid=m.project.pid,
-            date="{}-{}-{}".format(m.added.year, m.added.month, m.added.day))
-        self.assertEqual(response.status_code, 200)
+        with self.settings(USE_TZ=False):
+            m = MessageFactory()
+            request = RequestFactory().get(m.get_absolute_url())
+            response = ChatArchiveDate.as_view()(
+                request, pid=m.project.pid,
+                date="{}-{}-{}".format(
+                    m.added.year, m.added.month, m.added.day))
+            self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.context_data['project'], m.project)
-        self.assertTrue(m in response.context_data['chat_messages'])
+            self.assertEqual(response.context_data['project'], m.project)
+            self.assertTrue(m in response.context_data['chat_messages'])

--- a/dmt/main/tests/test_views.py
+++ b/dmt/main/tests/test_views.py
@@ -1505,7 +1505,7 @@ class TestFeeds(TestCase):
             s.author.userprofile.email,
             s.author.userprofile.get_fullname()) in r.content)
         self.assertTrue("<pubDate>{}</pubDate>".format(
-            s.added.strftime("%a, %02d %b %Y %H:%M:%S %z")) in r.content)
+            s.added.strftime("%a, %d %b %Y %H:%M:%S %z")) in r.content)
         self.assertTrue("<content:encoded>" in r.content)
 
     def test_project_feed(self):


### PR DESCRIPTION
In developing on DMT, I've noticed that a few tests always fail in the evening. I
tracked these down tonight to timezone issues. For testing purposes, I simply
turned off the USE_TZ setting to False for the individual tests.

Worth noting: I've also removed some code that was attempting to set a model's "added" attribute. This had no effect as the "added" attribute has auto_now_add=True specified.