### PR TITLE
leveraging eslint for security checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
         "scanjs-rules/call_connect": 1,
         "scanjs-rules/call_eval": 1,
         "scanjs-rules/call_execScript": 1,
-        "scanjs-rules/call_hide": 1,
+        "scanjs-rules/call_hide": 0, /* hide used often. overly cautious */
         "scanjs-rules/call_open_remote=true": 1,
         "scanjs-rules/call_parseFromString": 1,
         "scanjs-rules/call_setImmediate": 1,
@@ -73,18 +73,18 @@ module.exports = {
         "scanjs-rules/property_mgmt": 1,
         "scanjs-rules/property_sessionStorage": 1,
 
-        'security/detect-buffer-noassert': 'warn',
-        'security/detect-child-process': 'warn',
-        'security/detect-disable-mustache-escape': 'warn',
-        'security/detect-eval-with-expression': 'warn',
-        'security/detect-new-buffer': 'warn',
-        'security/detect-no-csrf-before-method-override': 'warn',
-        'security/detect-non-literal-fs-filename': 'warn',
-        'security/detect-non-literal-regexp': 'warn',
-        'security/detect-non-literal-require': 'warn',
-        'security/detect-object-injection': 'warn',
-        'security/detect-possible-timing-attacks': 'warn',
-        'security/detect-pseudoRandomBytes': 'warn',
-        'security/detect-unsafe-regex': 'warn'
+        'security/detect-buffer-noassert': 1,
+        'security/detect-child-process': 1,
+        'security/detect-disable-mustache-escape': 1,
+        'security/detect-eval-with-expression': 1,
+        'security/detect-new-buffer': 1,
+        'security/detect-no-csrf-before-method-override': 1,
+        'security/detect-non-literal-fs-filename': 1,
+        'security/detect-non-literal-regexp': 1,
+        'security/detect-non-literal-require': 0, /* requirejs conflict */
+        'security/detect-object-injection': 0, /* several false positives */
+        'security/detect-possible-timing-attacks': 1,
+        'security/detect-pseudoRandomBytes': 1,
+        'security/detect-unsafe-regex': 1
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,15 @@ module.exports = {
         "amd": true,
         "jquery": true
     },
+    "plugins": [
+        "security",
+        "scanjs-rules",
+        "no-unsafe-innerhtml"
+    ],
+    "extends": [
+        "eslint:recommended",
+        "plugin:security/recommended"
+    ],  
     "extends": "eslint:recommended",
     "rules": {
         "indent": [
@@ -25,6 +34,57 @@ module.exports = {
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        /** no-unsafe-innerhtml rule **/
+        "no-unsafe-innerhtml/no-unsafe-innerhtml" : 2,
+
+        /** ScanJS rules **/
+        "scanjs-rules/assign_to_hostname": 1,
+        "scanjs-rules/assign_to_href": 1,
+        "scanjs-rules/assign_to_location": 1,
+        "scanjs-rules/assign_to_onmessage": 1,
+        "scanjs-rules/assign_to_pathname": 1,
+        "scanjs-rules/assign_to_protocol": 1,
+        "scanjs-rules/assign_to_search": 1,
+        "scanjs-rules/assign_to_src": 1,
+        "scanjs-rules/call_Function": 1,
+        "scanjs-rules/call_addEventListener": 1,
+        "scanjs-rules/call_addEventListener_deviceproximity": 1,
+        "scanjs-rules/call_addEventListener_message": 1,
+        "scanjs-rules/call_connect": 1,
+        "scanjs-rules/call_eval": 1,
+        "scanjs-rules/call_execScript": 1,
+        "scanjs-rules/call_hide": 1,
+        "scanjs-rules/call_open_remote=true": 1,
+        "scanjs-rules/call_parseFromString": 1,
+        "scanjs-rules/call_setImmediate": 1,
+        "scanjs-rules/call_setInterval": 1,
+        "scanjs-rules/call_setTimeout": 1,
+        "scanjs-rules/identifier_indexedDB": 1,
+        "scanjs-rules/identifier_localStorage": 1,
+        "scanjs-rules/identifier_sessionStorage": 1,
+        "scanjs-rules/new_Function": 1,
+        "scanjs-rules/property_addIdleObserver": 1,
+        "scanjs-rules/property_createContextualFragment": 1,
+        "scanjs-rules/property_geolocation": 1,
+        "scanjs-rules/property_getUserMedia": 1,
+        "scanjs-rules/property_indexedDB": 1,
+        "scanjs-rules/property_localStorage": 1,
+        "scanjs-rules/property_mgmt": 1,
+        "scanjs-rules/property_sessionStorage": 1,
+
+        'security/detect-buffer-noassert': 'warn',
+        'security/detect-child-process': 'warn',
+        'security/detect-disable-mustache-escape': 'warn',
+        'security/detect-eval-with-expression': 'warn',
+        'security/detect-new-buffer': 'warn',
+        'security/detect-no-csrf-before-method-override': 'warn',
+        'security/detect-non-literal-fs-filename': 'warn',
+        'security/detect-non-literal-regexp': 'warn',
+        'security/detect-non-literal-require': 'warn',
+        'security/detect-object-injection': 'warn',
+        'security/detect-possible-timing-attacks': 'warn',
+        'security/detect-pseudoRandomBytes': 'warn',
+        'security/detect-unsafe-regex': 'warn'
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
         "eslint:recommended",
         "plugin:security/recommended"
     ],  
-    "extends": "eslint:recommended",
     "rules": {
         "indent": [
             "error",

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ karma-test-results.xml
 wheelhouse
 media/*built.js
 .settings
+package-lock.json

--- a/media/js/src/chat.js
+++ b/media/js/src/chat.js
@@ -1,4 +1,5 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+/* eslint "scanjs-rules/call_setTimeout": 0 */
 
 require.config({
     map: {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,17 @@
   "version": "0.1.0",
   "description": "Project management tool",
   "license": "GPL-2.0+",
+  "eslintConfig": {
+    "extends": "secure"
+  },
   "scripts": {
     "test": "karma start"
   },
   "devDependencies": {
     "eslint": "~4.4.0",
+    "eslint-config-scanjs": "^1.0.0-beta4",
+    "eslint-plugin-no-unsafe-innerhtml": "^1.0.16",
+    "eslint-plugin-security": "^1.4.0",
     "jscs": "~3.0.7",
     "jshint": "~2.9.1",
     "karma": "~1.7.0",


### PR DESCRIPTION
per recommendations from: https://before-you-ship.18f.gov/security/static-analysis/#javascript

* adding [eslint-config-scanjs](https://www.npmjs.com/package/eslint-config-scanjs), Mozilla's port of its security static analyzer
* adding [eslint-plugin-no-unsafe-innerhtml](https://www.npmjs.com/package/eslint-plugin-no-unsafe-innerhtml)
* also, adding additional checks from [eslint-config-secure](https://github.com/nodesecurity/eslint-plugin-security)

I've resolved all warnings in DMT, which consisted of several false positives. I'm hoping this will serve as a model for all our projects.