### PR TITLE
Add Jenkins to Travis make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ media/main-built.js: $(JS_SENTINAL) build.js media/js/src media/js/libs
 media/chat-built.js: $(JS_SENTINAL) chat-build.js media/js/src/chat.js media/js/libs
 	$(REQUIREJS) -o chat-build.js
 
-travis: $(JS_SENTINAL) parallel-tests jstest integration
+travis: $(JS_SENTINAL) parallel-tests jstest integration jenkins
 
 js: media/main-built.js media/chat-built.js
 


### PR DESCRIPTION
Adding 'jenkins' to this target will kick off a number of tests which
currently aren't being run by Travis.