### PR TITLE
Remove jQuery override on milestone page

### DIFF
--- a/dmt/templates/main/milestone_detail.html
+++ b/dmt/templates/main/milestone_detail.html
@@ -111,18 +111,12 @@
         </label>
         <button type="submit" class="btn btn-primary btn-sm"
                 title="Run the selected action">Go</button>
-
-        <span class="action-counter help-block"
-              data-actions-icnt="{{object.item_set.count}}"
-              style="display: inline;">
-            0 of {{object.item_set.count}} selected
-        </span>
     </div>
 <table class="table table-condensed table-striped tablesorter tablesorter-default">
     <thead>
         <tr>
             <th scope="col" class="action-checkbox-column" data-sorter="false">
-                <div class="text"><span><input type="checkbox" id="action-toggle"></span></div>
+                <div class="text"></div>
                 <div class="clear"></div>
             </th>
             <th>Title</th>

--- a/dmt/templates/main/milestone_detail.html
+++ b/dmt/templates/main/milestone_detail.html
@@ -188,12 +188,4 @@
             });
         });
     </script>
-
-    <script src="/admin/jsi18n/"></script>
-    <script>
-    // A modified version of django's admin/js/jquery.init.js
-    var django = django || {};
-    django.jQuery = jQuery;
-    </script>
-    <script type="text/javascript" src="{% static 'admin/js/actions.js' %}"></script>
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,18 +43,6 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
-    "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
-      }
-    },
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
@@ -1154,20 +1142,20 @@
       }
     },
     "eslint": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.11.0.tgz",
+      "integrity": "sha512-UWbhQpaKlm8h5x/VLwm0S1kheMrDj8jPwhnBMjr/Dlo3qqT7MvcN/UfKAR3E1N4lr4YNtOvS4m3hwsrVc/ky7g==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
+        "ajv": "5.4.0",
         "babel-code-frame": "6.22.0",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -1180,7 +1168,7 @@
         "inquirer": "3.2.1",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.9.1",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -1198,6 +1186,24 @@
         "text-table": "0.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
+          "integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1214,9 +1220,9 @@
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -1234,12 +1240,12 @@
           }
         },
         "espree": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-          "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+          "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
           "dev": true,
           "requires": {
-            "acorn": "5.1.1",
+            "acorn": "5.2.1",
             "acorn-jsx": "3.0.1"
           }
         },
@@ -1269,7 +1275,7 @@
       "integrity": "sha1-YsqLQH6gksO01DATuttuep4tqsM=",
       "dev": true,
       "requires": {
-        "eslint": "4.9.0",
+        "eslint": "4.11.0",
         "eslint-plugin-no-unsanitized": "2.0.1",
         "eslint-plugin-no-wildcard-postmessage": "0.1.3",
         "eslint-plugin-scanjs-rules": "0.2.1"
@@ -2042,7 +2048,7 @@
       "dev": true,
       "requires": {
         "babel-eslint": "8.0.1",
-        "eslint": "4.9.0"
+        "eslint": "4.11.0"
       }
     },
     "eslint-plugin-security": {
@@ -2312,6 +2318,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -3115,6 +3127,12 @@
         "jsonify": "0.0.0"
       }
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3167,12 +3185,6 @@
           "dev": true
         }
       }
-    },
-    "just-extend": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
-      "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8=",
-      "dev": true
     },
     "karma": {
       "version": "1.7.0",
@@ -3622,12 +3634,6 @@
         }
       }
     },
-    "lolex": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.2.tgz",
-      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik=",
-      "dev": true
-    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -3752,12 +3758,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3769,6 +3769,33 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "just-extend": {
+          "version": "1.1.27",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+          "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+          "dev": true
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        }
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -4509,42 +4536,33 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.0.tgz",
-      "integrity": "sha1-pUpfAjeqHdIhXl6ByJtCtQxP22s=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.2.tgz",
+      "integrity": "sha512-5uLBZPdCWl59Lpbf45ygKj7Z0LVol+ftBe7RDIXOQV/sF58pcFmbK8raA7bt6eljNuGnvBP+/ZxlicVn0emDjA==",
       "dev": true,
       "requires": {
         "diff": "3.3.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.1.2",
-        "native-promise-only": "0.8.1",
-        "nise": "1.1.0",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.2.1",
-        "text-encoding": "0.6.4",
+        "lolex": "2.3.0",
+        "nise": "1.2.0",
+        "supports-color": "4.5.0",
         "type-detect": "4.0.3"
       },
       "dependencies": {
-        "nise": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.0.tgz",
-          "integrity": "sha512-lIFidCxB0mJGyq1i33tLRNojtMoYX95EAI7WQEU+/ees0w6hvXZQHZ7WD130Tjeh5+YJAUVLfQ3k/s9EA8jj+w==",
+        "lolex": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.0.tgz",
+          "integrity": "sha512-rPO6R1t8PjYL6xbsFUg7aByKkWAql907na6powPBORVs4DCm8aMBUkL4+6CXO0gEIV8vtu3mWV0FB8ZaCYPBmA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "formatio": "1.2.0",
-            "just-extend": "1.1.22",
-            "lolex": "1.6.0",
-            "path-to-regexp": "1.7.0",
-            "text-encoding": "0.6.4"
-          },
-          "dependencies": {
-            "lolex": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-              "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-              "dev": true
-            }
+            "has-flag": "2.0.0"
           }
         }
       }


### PR DESCRIPTION
Resolves Sentry error `$("table.tablesorter").tablesorter is not a function.` that occurs when accessing a milestone page in Safari. The overridden jQuery appears to interfere with the tablesorter loading properly. The page functionality, particularly the mass reassignment/move feature, appears to work fine without this code. (But please double-check me on this one.)