### PR TITLE
reports: Use left join on actual_time

### DIFF
--- a/dmt/report/calculators.py
+++ b/dmt/report/calculators.py
@@ -49,7 +49,7 @@ select
 from projects
 join milestones on (projects.pid = milestones.pid)
 join items on (milestones.mid = items.mid)
-join actual_times on (items.iid = actual_times.iid)
+left join actual_times on (items.iid = actual_times.iid)
 join users on (items.assigned_user = users.user_id)
 where projects.status != 'Defunct' and projects.status != 'Non-project'
     and projects.pub_view
@@ -76,7 +76,7 @@ select
 from projects
 join milestones on (projects.pid = milestones.pid)
 join items on (milestones.mid = items.mid)
-join actual_times on (items.iid = actual_times.iid)
+left join actual_times on (items.iid = actual_times.iid)
 where projects.status != 'Defunct' and projects.status != 'Non-project'
     and projects.pub_view
 and actual_times.completed >= '2017-01-23'

--- a/dmt/report/calculators.py
+++ b/dmt/report/calculators.py
@@ -79,7 +79,6 @@ join items on (milestones.mid = items.mid)
 left join actual_times on (items.iid = actual_times.iid)
 where projects.status != 'Defunct' and projects.status != 'Non-project'
     and projects.pub_view
-and actual_times.completed >= '2017-01-23'
 group by projects.pid
 order by due_date, projects.name
 limit 100000;


### PR DESCRIPTION
This fixes a bug where items with no logged time aren't reported.