### PR TITLE
Exclude defunct projects from being searched

### DIFF
--- a/dmt/main/views.py
+++ b/dmt/main/views.py
@@ -97,8 +97,11 @@ class SearchView(LoggedInMixin, TemplateView):
                 Q(comments__icontains=q)
             ),
             projects=Project.objects.filter(
-                Q(name__icontains=q) |
-                Q(description__icontains=q)
+                ~Q(status='Defunct') &
+                (
+                    Q(name__icontains=q) |
+                    Q(description__icontains=q)
+                )
             ),
             milestones=Milestone.objects.filter(
                 Q(name__icontains=q) |
@@ -107,10 +110,13 @@ class SearchView(LoggedInMixin, TemplateView):
             # TODO: comments/events for items should also be searched
             # and merged in.
             items=Item.objects.filter(
-                Q(title__icontains=q) |
-                Q(iid__iexact=q) |
-                Q(iid__iexact=item_id) |
-                Q(description__icontains=q)
+                ~Q(milestone__project__status='Defunct') &
+                (
+                    Q(title__icontains=q) |
+                    Q(iid__iexact=q) |
+                    Q(iid__iexact=item_id) |
+                    Q(description__icontains=q)
+                )
             ).annotate(
                 workedon_total=Sum('actualtime__actual_time')
             ),


### PR DESCRIPTION
This commit is to exclude defunct projects and items from defunct projects from being returned as search results. Can I get an honest review on this, see if I'm doing it correctly code-wise?