### PR TITLE
Set up staff capacity report

### DIFF
--- a/dmt/report/calculators.py
+++ b/dmt/report/calculators.py
@@ -1,6 +1,9 @@
 from datetime import date
+
 from django.db import connection
 from django.db.models import Q, Sum
+import numpy
+
 from dmt.main.models import Project, Item
 
 
@@ -138,3 +141,34 @@ class ProjectStatusCalculator(object):
             ])
 
         return sorted(report, key=lambda row: row[3] or date(2000, 1, 1))
+
+
+class StaffCapacityCalculator(object):
+
+    def __init__(self, users, start, end):
+        self.users = users
+        self.interval_start = start
+        self.interval_end = end
+
+    def holidays(self):
+        # http://hr.columbia.edu/events/holidays
+        dates = ['2018-01-01', '2018-01-02', '2018-01-15', '2018-02-19',
+                 '2018-05-28', '2018-07-04', '2018-09-03', '2018-11-06',
+                 '2018-11-22', '2018-11-23', '2018-12-24', '2018-12-25',
+                 '2018-12-31', '2019-01-01']
+        return [numpy.datetime64(x) for x in dates]
+
+    def days(self):
+        return numpy.busday_count(self.interval_start, self.interval_end,
+                                  holidays=self.holidays())
+
+    def capacity_for_range(self):
+        return self.days() * 6
+
+    def calc(self):
+        user_data = []
+        for user in self.users:
+            user_data.append({
+                'user': user,
+            })
+        return user_data

--- a/dmt/report/urls.py
+++ b/dmt/report/urls.py
@@ -43,4 +43,11 @@ urlpatterns = [
         name='time_spent_by_project_report'),
     url(r'^project_status/$', views.ProjectStatus.as_view(),
         name='project_status_report'),
+
+    url(r'^capacity/$', views.StaffCapacityView.as_view(),
+        name='staff_capacity'),
+    url(r'^staff/capacity\w{0,50}$', views.StaffCapacityExportView.as_view(),
+        name='staff_capacity_export'),
+
+
 ]

--- a/dmt/templates/report/report_list.html
+++ b/dmt/templates/report/report_list.html
@@ -20,7 +20,8 @@
     <li><a href="{% url 'passed_milestones_report' %}">Passed Milestones</a></li>
     <li><a href="{% url 'resolved_items_report' %}">Resolved Items</a></li>
     <li><a href="{% url 'inprogress_items_report' %}">In Progress Items</a></li>
-    <li><a href="{% url 'staff_report' %}">Staff Report</a></li>
+    <li><a href="{% url 'staff_report' %}">Staff Task Report</a></li>
+    <li><a href="{% url 'staff_capacity' %}">Staff Capacity Report</a></li>
 
     <li><a href="{% url 'yearly_review_report' %}">Your Yearly Review</a></li>
 

--- a/dmt/templates/report/staff_capacity.html
+++ b/dmt/templates/report/staff_capacity.html
@@ -1,0 +1,64 @@
+{% extends 'base.html' %}
+{% load dmttags %}
+
+{% block title %}Staff Capacity{% endblock %}
+
+{% block primarynavtabs %}
+{% endblock %}
+
+{% block primarynavtabsright %}
+{% endblock %}
+
+{% block content %}
+<ul class="breadcrumb">
+    <li><a href="/"><span class="glyphicon glyphicon-home"></span></a></li>
+    <li><a href="{% url 'report_list' %}">Reports</a></li>
+    <li class="active">Staff Capacity</li>
+</ul>
+
+<h2>Staff Report</h2>
+
+{% include 'main/daterange_form.html' %}
+
+<div class="col-md-3">
+    Export as:
+    <a href="{% url 'staff_capacity_export' %}?format=csv&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
+    >.csv</a>,
+    <a href="{% url 'staff_capacity_export' %}?format=xlsx&interval_start={{interval_start|format_ymd}}&interval_end={{interval_end|format_ymd}}"
+    >.xlsx</a>
+</div>
+
+<div class="clearfix"></div>
+<p class="help-block">Calculated {{days}} business days in this period. 2018 holidays are excluded.</p>
+
+<table class="table table-striped table-condensed tablesorter tablesorter-default" id="staff-report">
+    <thead>
+        <th>Staff Member</th>
+        <th>Capacity</th>
+    </thead>
+    <tbody>
+        {% for user in users %}
+        <tr>
+            <td>
+                <a href="{% url 'user_detail' user.user.username %}">
+                    {% firstof user.user.fullname user.user.username %}
+                </a>
+            </td>
+            <td>{{capacity}}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}
+
+{% block js %}
+<script>
+$(document).ready(function() {
+    $("#staff-report").tablesorter({
+        // Sort by items resolved, descending, then hours logged, descending.
+        sortList: [[1, 1], [2, 1]]
+    });
+});
+</script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -153,3 +153,5 @@ pbr==3.1.1
 PyYAML>=3.10.0 # MIT
 stevedore>=1.20.0 # Apache-2.0
 bandit==1.4.0
+
+numpy==1.14.1


### PR DESCRIPTION
* Set up the staff capacity report to allow reporting based on a date range. Uses existing structure and ui that support date range queries.
* Leverage `numpy.busday_count` to determine capacity for a given date range. Excludes weekends and 2018 CU holidays.