### PR TITLE
Estimated time sort fix

### DIFF
--- a/dmt/main/models.py
+++ b/dmt/main/models.py
@@ -988,7 +988,7 @@ WHERE p.pid = m.pid
                 'time': u.total_estimated_time_by_project(self),
             })
 
-        return sorted(rows, key=lambda x: x.get('time'))
+        return sorted(rows, key=lambda x: x.get('time'), reverse=True)
 
     def timeline(self, start=None, end=None):
         all_events = []


### PR DESCRIPTION
Sort this table by time descending instead of ascending. The JavaScript
sorts this table anyways, but sometimes that doesn't load.