### PR TITLE
Update PMT email to ctl.columbia.edu - PMT #116371

### DIFF
--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -89,7 +89,7 @@ MESSAGE_TAGS = {
     messages.ERROR: 'danger'
 }
 
-SERVER_EMAIL = 'pmt@ccnmtl.columbia.edu'
+SERVER_EMAIL = 'pmt@ctl.columbia.edu'
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
 EMAIL_MAX_RETRIES = 10


### PR DESCRIPTION
This should work because we now control the ctl.columbia.edu domain in
SES.