### PR TITLE
Make seconds_to_hours accept None - fixes sentry error

### DIFF
--- a/dmt/main/tasks.py
+++ b/dmt/main/tasks.py
@@ -122,6 +122,9 @@ def hours_logged_report():
 
 
 def seconds_to_hours(seconds):
+    if not seconds:
+        seconds = 0
+
     return seconds / 3600.
 
 

--- a/dmt/main/tests/test_tasks.py
+++ b/dmt/main/tests/test_tasks.py
@@ -28,6 +28,9 @@ class TestHelpers(TestCase):
 
     def test_seconds_to_hours(self):
         self.assertEqual(seconds_to_hours(3600), 1.)
+        self.assertEqual(seconds_to_hours(None), 0)
+        self.assertEqual(seconds_to_hours(0), 0)
+        self.assertEqual(seconds_to_hours(3600 / 2), 0.5)
 
 
 class TestBumpSomedayMaybe(TestCase):


### PR DESCRIPTION
https://sentry.io/columbia-ctl/dmt/issues/731841525/