### PR TITLE
Time spent by user report backslash fix - PMT #117115

### DIFF
--- a/dmt/report/calculators.py
+++ b/dmt/report/calculators.py
@@ -52,7 +52,7 @@ select
         projects.due_date as project_due_date,
         caretakers.fullname as caretaker,
         items.description as task_description,
-        string_agg(
+        '\\\\ ' || string_agg(
             distinct to_char(comments.add_date_time, 'MM/DD/YYYY') || '; ' ||
             comments.username || '; ' || comments.comment_src,
             '\\\\ ')


### PR DESCRIPTION
Add two backslashes and a space before the first comment in the comment
history in this report.