### PR TITLE
Travis: npm update command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.6"
 before_script:
   - psql -c 'create database ci_test;' -U postgres
-  - npm install --upgrade npm
+  - npm install -g npm@latest 
 script:
   - make flake8
   - make travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ addons:
 python:
   - "2.7"
   - "3.6"
+cache:
+  npm: false
 before_script:
   - psql -c 'create database ci_test;' -U postgres
   - npm install -g npm@latest 


### PR DESCRIPTION
It looks like Travis changed the base version of npm, which broke the
syntax for the update npm command. This commit changes it to the suggested
value in npm's docs:
https://docs.npmjs.com/try-the-latest-stable-version-of-npm