### PR TITLE
Migrate to ctlsettings

### DIFF
--- a/dmt/settings_docker.py
+++ b/dmt/settings_docker.py
@@ -69,11 +69,6 @@ if AWS_S3_CUSTOM_DOMAIN:
     # static data, e.g. css, js, etc.
     STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
     STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
-    COMPRESS_ENABLED = True
-    COMPRESS_OFFLINE = True
-    COMPRESS_ROOT = STATIC_ROOT
-    COMPRESS_URL = STATIC_URL
-    COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
 
 if RAVEN_DSN and 'migrate' not in sys.argv:
     INSTALLED_APPS.append('raven.contrib.django.raven_compat')

--- a/dmt/settings_production.py
+++ b/dmt/settings_production.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from dmt.settings_shared import *
-from ccnmtlsettings.production import common
+from ctlsettings.production import common
 import os
 
 project = 'dmt'

--- a/dmt/settings_shared.py
+++ b/dmt/settings_shared.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import os.path
 import sys
 
-from ccnmtlsettings.shared import common
+from ctlsettings.shared import common
 from django.contrib import messages
 
 
@@ -33,12 +33,14 @@ MIDDLEWARE += [  # noqa
 
 INSTALLED_APPS += [  # noqa
     'django_extensions',
-    'django_cas_ng',
+    'waffle',
+    'django_markwhat',
     'rest_framework',
     'taggit',
     'taggit_templatetags2',
     'bootstrap3',
     'emoji',
+
     'dmt.main',
     'dmt.report',
     'dmt.api',
@@ -47,7 +49,6 @@ INSTALLED_APPS += [  # noqa
     'crispy_forms',
 ]
 
-INSTALLED_APPS.remove('djangowind')  # noqa
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 AUTHENTICATION_BACKENDS = [
@@ -83,19 +84,6 @@ DEFAULT_FROM_EMAIL = SERVER_EMAIL
 EMAIL_MAX_RETRIES = 10
 
 DASHBOARD_GRAPH_TIMESPAN = '4weeks'
-
-CAS_SERVER_URL = 'https://cas.columbia.edu/cas/'
-CAS_VERSION = '3'
-CAS_ADMIN_REDIRECT = False
-
-# Translate CUIT's CAS user attributes to the Django user model.
-# https://cuit.columbia.edu/content/cas-3-ticket-validation-response
-CAS_APPLY_ATTRIBUTES_TO_USER = True
-CAS_RENAME_ATTRIBUTES = {
-    'givenName': 'first_name',
-    'lastName': 'last_name',
-    'mail': 'email',
-}
 
 TEMPLATES = [
     {

--- a/dmt/settings_staging.py
+++ b/dmt/settings_staging.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from dmt.settings_shared import *
-from ccnmtlsettings.staging import common
+from ctlsettings.staging import common
 import os
 
 project = 'dmt'

--- a/dmt/templates/base.html
+++ b/dmt/templates/base.html
@@ -1,5 +1,4 @@
 {% load bootstrap3 %}
-{% load compress %}
 {% load waffle_tags %}
 {% load static %}
 
@@ -15,18 +14,14 @@
 
   {% bootstrap_css %}
 
-  {% compress css %}
   <link href="{{STATIC_URL}}css/main.css?dmt" rel="stylesheet">
-  {% endcompress %}
 
-  {% compress css %}
   <link rel="stylesheet" href="{{STATIC_URL}}css/bootstrap-datepicker3.css">
   <link rel="stylesheet" href="{{STATIC_URL}}datatables/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="{{STATIC_URL}}datatables/css/buttons.dataTables.css">
   <link rel="stylesheet" href="{{STATIC_URL}}css/theme.tablesorter.default.css">
   <link rel="stylesheet" href="{{STATIC_URL}}css/select2.min.css">
   <link rel="stylesheet" href="{{STATIC_URL}}css/emoji.css">
-  {% endcompress %}
 
   {% block css %}{% endblock %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,9 +89,6 @@ django-cas-ng==4.3.0
 
 django-staticmedia==0.2.2
 django-appconf==1.0.5
-rcssmin==1.1.1  # django-compressor
-rjsmin==1.2.1  # django-compressor
-django-compressor>=3.1,<5.0
 django-statsd-mozilla==0.4.0
 raven==6.10.0
 django-debug-toolbar==3.8.1
@@ -129,7 +126,7 @@ django-markwhat==1.6.2
 django-s3sign==0.3.2
 django-smtp-ssl==1.0
 
-ccnmtlsettings==1.9.4
+ctlsettings==0.1.0
 
 pbr==5.11.1
 pyyaml==6.0


### PR DESCRIPTION
Notably, this tentative change removes django-compressor. We'll see how this works throughout our deployment workflow.